### PR TITLE
fix: header bar overflow on firefox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Changelog
 
+## Unreleased
+
+### Fixed
+
+- Header bar overflow at some zoom levels on Firefox ([#21](https://github.com/tommilligan/mdbook-admonish/pull/21), thanks to [@sgoudham](https://github.com/sgoudham) for the report)
+
 ## 1.5.0
 
 ### Added

--- a/book/book.toml
+++ b/book/book.toml
@@ -9,7 +9,7 @@ title = "The mdbook-admonish book"
 
 [preprocessor.admonish]
 command = "mdbook-admonish"
-assets_version ="1.0.0" # do not edit: managed by `mdbook-admonish install`
+assets_version = "1.0.0" # do not edit: managed by `mdbook-admonish install`
 
 [output]
 

--- a/compile_assets/scss/admonition.scss
+++ b/compile_assets/scss/admonition.scss
@@ -133,12 +133,9 @@ a.admonition-anchor-link {
   margin-block: 0;
   margin-inline: -1.6rem -1.2rem;
   padding-block: 0.8rem;
-  padding-inline: 4rem 1.2rem;
+  padding-inline: 4.4rem 1.2rem;
   font-weight: 700;
   background-color: color.adjust($clr-blue-a200, $alpha: -0.9);
-  border: 0 solid $clr-blue-a200;
-  border-inline-start-width: 0.4rem;
-  border-start-start-radius: 0.2rem;
   // Compatilility with rendering markdown inside the content
   display: flex;
 
@@ -156,7 +153,7 @@ a.admonition-anchor-link {
   &::before {
     position: absolute;
     top: 0.625em;
-    inset-inline-start: 1.2rem;
+    inset-inline-start: 1.6rem;
     width: 2rem;
     height: 2rem;
     background-color: $clr-blue-a200;
@@ -192,7 +189,6 @@ a.admonition-anchor-link {
   // Admonition flavour title
   :is(#{$flavours}) > :is(.admonition-title, summary) {
     background-color: color.adjust($tint, $alpha: -0.9);
-    border-color: $tint;
 
     // Admonition icon
     &::before {

--- a/src/bin/assets/mdbook-admonish.css
+++ b/src/bin/assets/mdbook-admonish.css
@@ -68,12 +68,9 @@ a.admonition-anchor-link:link:hover, a.admonition-anchor-link:visited:hover {
   margin-block: 0;
   margin-inline: -1.6rem -1.2rem;
   padding-block: 0.8rem;
-  padding-inline: 4rem 1.2rem;
+  padding-inline: 4.4rem 1.2rem;
   font-weight: 700;
   background-color: rgba(68, 138, 255, 0.1);
-  border: 0 solid #448aff;
-  border-inline-start-width: 0.4rem;
-  border-start-start-radius: 0.2rem;
   display: flex;
 }
 :is(.admonition-title, summary) p {
@@ -85,7 +82,7 @@ html :is(.admonition-title, summary):last-child {
 :is(.admonition-title, summary)::before {
   position: absolute;
   top: 0.625em;
-  inset-inline-start: 1.2rem;
+  inset-inline-start: 1.6rem;
   width: 2rem;
   height: 2rem;
   background-color: #448aff;
@@ -104,7 +101,6 @@ html :is(.admonition-title, summary):last-child {
 
 :is(.note) > :is(.admonition-title, summary) {
   background-color: rgba(68, 138, 255, 0.1);
-  border-color: #448aff;
 }
 :is(.note) > :is(.admonition-title, summary)::before {
   background-color: #448aff;
@@ -122,7 +118,6 @@ html :is(.admonition-title, summary):last-child {
 
 :is(.abstract, .summary, .tldr) > :is(.admonition-title, summary) {
   background-color: rgba(0, 176, 255, 0.1);
-  border-color: #00b0ff;
 }
 :is(.abstract, .summary, .tldr) > :is(.admonition-title, summary)::before {
   background-color: #00b0ff;
@@ -140,7 +135,6 @@ html :is(.admonition-title, summary):last-child {
 
 :is(.info, .todo) > :is(.admonition-title, summary) {
   background-color: rgba(0, 184, 212, 0.1);
-  border-color: #00b8d4;
 }
 :is(.info, .todo) > :is(.admonition-title, summary)::before {
   background-color: #00b8d4;
@@ -158,7 +152,6 @@ html :is(.admonition-title, summary):last-child {
 
 :is(.tip, .hint, .important) > :is(.admonition-title, summary) {
   background-color: rgba(0, 191, 165, 0.1);
-  border-color: #00bfa5;
 }
 :is(.tip, .hint, .important) > :is(.admonition-title, summary)::before {
   background-color: #00bfa5;
@@ -176,7 +169,6 @@ html :is(.admonition-title, summary):last-child {
 
 :is(.success, .check, .done) > :is(.admonition-title, summary) {
   background-color: rgba(0, 200, 83, 0.1);
-  border-color: #00c853;
 }
 :is(.success, .check, .done) > :is(.admonition-title, summary)::before {
   background-color: #00c853;
@@ -194,7 +186,6 @@ html :is(.admonition-title, summary):last-child {
 
 :is(.question, .help, .faq) > :is(.admonition-title, summary) {
   background-color: rgba(100, 221, 23, 0.1);
-  border-color: #64dd17;
 }
 :is(.question, .help, .faq) > :is(.admonition-title, summary)::before {
   background-color: #64dd17;
@@ -212,7 +203,6 @@ html :is(.admonition-title, summary):last-child {
 
 :is(.warning, .caution, .attention) > :is(.admonition-title, summary) {
   background-color: rgba(255, 145, 0, 0.1);
-  border-color: #ff9100;
 }
 :is(.warning, .caution, .attention) > :is(.admonition-title, summary)::before {
   background-color: #ff9100;
@@ -230,7 +220,6 @@ html :is(.admonition-title, summary):last-child {
 
 :is(.failure, .fail, .missing) > :is(.admonition-title, summary) {
   background-color: rgba(255, 82, 82, 0.1);
-  border-color: #ff5252;
 }
 :is(.failure, .fail, .missing) > :is(.admonition-title, summary)::before {
   background-color: #ff5252;
@@ -248,7 +237,6 @@ html :is(.admonition-title, summary):last-child {
 
 :is(.danger, .error) > :is(.admonition-title, summary) {
   background-color: rgba(255, 23, 68, 0.1);
-  border-color: #ff1744;
 }
 :is(.danger, .error) > :is(.admonition-title, summary)::before {
   background-color: #ff1744;
@@ -266,7 +254,6 @@ html :is(.admonition-title, summary):last-child {
 
 :is(.bug) > :is(.admonition-title, summary) {
   background-color: rgba(245, 0, 87, 0.1);
-  border-color: #f50057;
 }
 :is(.bug) > :is(.admonition-title, summary)::before {
   background-color: #f50057;
@@ -284,7 +271,6 @@ html :is(.admonition-title, summary):last-child {
 
 :is(.example) > :is(.admonition-title, summary) {
   background-color: rgba(124, 77, 255, 0.1);
-  border-color: #7c4dff;
 }
 :is(.example) > :is(.admonition-title, summary)::before {
   background-color: #7c4dff;
@@ -302,7 +288,6 @@ html :is(.admonition-title, summary):last-child {
 
 :is(.quote, .cite) > :is(.admonition-title, summary) {
   background-color: rgba(158, 158, 158, 0.1);
-  border-color: #9e9e9e;
 }
 :is(.quote, .cite) > :is(.admonition-title, summary)::before {
   background-color: #9e9e9e;


### PR DESCRIPTION
Closes #20

The issue was the header bar rendering it's own border (which sometimes wouldn't match up with the full admonition border, for some reason).

The border I think was added for padding reasons in the original mkdocs implementation, here I've removed it in favour of adjusting some other padding/inset values.

### main

![image](https://user-images.githubusercontent.com/12255914/165472692-ca30f2d9-119c-4830-8c1d-6b198f5a401a.png)


### This PR

![image](https://user-images.githubusercontent.com/12255914/165472509-a985f30a-ad53-4eb2-bb0e-bfeef2f61f39.png)
