### PR TITLE
feat: add key/value configuration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -875,10 +875,14 @@ dependencies = [
  "env_logger 0.9.0",
  "log",
  "mdbook",
+ "once_cell",
  "pretty_assertions",
  "pulldown-cmark",
+ "regex",
  "semver",
+ "serde",
  "serde_json",
+ "toml",
  "toml_edit",
 ]
 
@@ -1403,6 +1407,9 @@ name = "serde"
 version = "1.0.136"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce31e24b01e1e524df96f1c2fdd054405f8d7376249a5110886fb4b658484789"
+dependencies = [
+ "serde_derive",
+]
 
 [[package]]
 name = "serde_derive"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,9 +27,13 @@ clap = { version = "3.0.14", default_features = false, features = ["std", "cargo
 env_logger = { version = "0.9.0", default_features = false, optional = true }
 log = { version = "0.4.14", optional = true }
 mdbook = "0.4.15"
+once_cell = "1.10.0"
 pulldown-cmark = "0.9.1"
+regex = "1.5.5"
 semver = "1.0.7"
+serde = { version = "1.0.136", features = ["derive"] }
 serde_json = "1.0.79"
+toml = "0.5.9"
 toml_edit = { version = "0.13.4", optional = true }
 
 [dev-dependencies]

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1,0 +1,156 @@
+use crate::types::Directive;
+use std::str::FromStr;
+
+mod v1;
+mod v2;
+
+#[derive(Debug, PartialEq)]
+pub(crate) struct AdmonitionInfoRaw {
+    directive: String,
+    title: Option<String>,
+    additional_classnames: Vec<String>,
+}
+
+/// Extract the remaining info string, if this is an admonition block.
+fn admonition_config_string(info_string: &str) -> Option<&str> {
+    const ADMONISH_BLOCK_KEYWORD: &str = "admonish";
+
+    // Get the rest of the info string if this is an admonition
+    if info_string == ADMONISH_BLOCK_KEYWORD {
+        return Some("");
+    }
+
+    match info_string.split_once(' ') {
+        Some((keyword, rest)) if keyword == ADMONISH_BLOCK_KEYWORD => Some(rest),
+        _ => None,
+    }
+}
+
+impl AdmonitionInfoRaw {
+    /// Returns:
+    /// - `None` if this is not an `admonish` block.
+    /// - `Some(AdmonitionInfoRaw)` if this is an `admonish` block
+    pub fn from_info_string(info_string: &str) -> Option<Result<Self, String>> {
+        let config_string = admonition_config_string(info_string)?;
+
+        // If we succeed at parsing v2, return that. Otherwise hold onto the error
+        let config_v2_error = match v1::from_config_string(config_string) {
+            Ok(config) => return Some(Ok(config)),
+            Err(config) => config,
+        };
+
+        Some(
+            if let Ok(info_raw) = v2::from_config_string(config_string) {
+                // If we succeed at parsing v1, return that.
+                Ok(info_raw)
+            } else {
+                // Otherwise return our v2 error.
+                Err(config_v2_error)
+            },
+        )
+    }
+}
+
+#[derive(Debug, PartialEq)]
+pub(crate) struct AdmonitionInfo {
+    pub directive: Directive,
+    pub title: Option<String>,
+    pub additional_classnames: Vec<String>,
+}
+
+impl AdmonitionInfo {
+    pub fn from_info_string(info_string: &str) -> Option<Self> {
+        AdmonitionInfoRaw::from_info_string(info_string).map(|result| {
+            result.map(Into::into).unwrap_or_else(|error| Self {
+                directive: Directive::Bug,
+                title: Some(error),
+                additional_classnames: Vec::new(),
+            })
+        })
+    }
+}
+
+impl From<AdmonitionInfoRaw> for AdmonitionInfo {
+    fn from(other: AdmonitionInfoRaw) -> Self {
+        let AdmonitionInfoRaw {
+            directive: raw_directive,
+            title,
+            additional_classnames,
+        } = other;
+        let (directive, title) = match (Directive::from_str(&raw_directive), title) {
+            (Ok(directive), None) => (directive, ucfirst(&raw_directive)),
+            (Err(_), None) => (Directive::Note, "Note".to_owned()),
+            (Ok(directive), Some(title)) => (directive, title),
+            (Err(_), Some(title)) => (Directive::Note, title),
+        };
+        // If the user explicitly gave no title, then disable the title bar
+        let title = if title.is_empty() { None } else { Some(title) };
+        Self {
+            directive,
+            title,
+            additional_classnames,
+        }
+    }
+}
+
+/// Make the first letter of `input` upppercase.
+///
+/// source: https://stackoverflow.com/a/38406885
+fn ucfirst(input: &str) -> String {
+    let mut chars = input.chars();
+    match chars.next() {
+        None => String::new(),
+        Some(f) => f.to_uppercase().collect::<String>() + chars.as_str(),
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn test_from_info_string() {
+        // Not admonition blocks
+        assert_eq!(AdmonitionInfoRaw::from_info_string(""), None);
+        assert_eq!(AdmonitionInfoRaw::from_info_string("adm"), None);
+        // v1 syntax is supported back compatibly
+        assert_eq!(
+            AdmonitionInfoRaw::from_info_string("admonish note.additional-classname")
+                .unwrap()
+                .unwrap(),
+            AdmonitionInfoRaw {
+                directive: "note".to_owned(),
+                title: None,
+                additional_classnames: vec!["additional-classname".to_owned()]
+            }
+        );
+        // v2 syntax is supported
+        assert_eq!(
+            AdmonitionInfoRaw::from_info_string(r#"admonish title="Custom Title" type="question""#)
+                .unwrap()
+                .unwrap(),
+            AdmonitionInfoRaw {
+                directive: "question".to_owned(),
+                title: Some("Custom Title".to_owned()),
+                additional_classnames: Vec::new(),
+            }
+        );
+    }
+
+    #[test]
+    fn test_admonition_info_from_raw() {
+        assert_eq!(
+            AdmonitionInfo::from(AdmonitionInfoRaw {
+                directive: " ".to_owned(),
+                title: None,
+                additional_classnames: Vec::new(),
+            }),
+            AdmonitionInfo {
+                directive: Directive::Note,
+                title: Some("Note".to_owned()),
+                additional_classnames: Vec::new(),
+            }
+        );
+    }
+}

--- a/src/config/v1.rs
+++ b/src/config/v1.rs
@@ -1,0 +1,124 @@
+use super::AdmonitionInfoRaw;
+use once_cell::sync::Lazy;
+use regex::Regex;
+
+pub(crate) fn from_config_string(config_string: &str) -> Result<AdmonitionInfoRaw, String> {
+    let config_string = config_string.trim();
+
+    static RX_CONFIG_STRING_V1: Lazy<Regex> = Lazy::new(|| {
+        let directive = r#"[a-z]+"#;
+        let css_classname = r#"-?[_a-zA-Z]+[_a-zA-Z0-9-]*"#;
+        let title = r#"".*""#;
+        Regex::new(&format!(
+            "^({directive})?(\\.({css_classname})?)*( {title})?$"
+        ))
+        .expect("config string v1 regex")
+    });
+
+    // Check if this is a valid looking v1 directive
+    if !RX_CONFIG_STRING_V1.is_match(config_string) {
+        return Err("Invalid configuration string".to_owned());
+    }
+
+    // If we're just given the directive, handle that
+    let (directive, title) = config_string
+        .split_once(' ')
+        .map(|(directive, title)| (directive, Some(title)))
+        .unwrap_or_else(|| (config_string, None));
+
+    // The title is expected to be a quoted JSON string
+    // If parsing fails, output the error message as the title for the user to correct
+    let title = title
+        .map(|title| {
+            serde_json::from_str::<String>(title)
+                .map_err(|error| format!("Error parsing JSON string: {error}"))
+        })
+        .transpose()?;
+
+    // If the directive contains additional classes, parse them out
+    const CLASSNAME_SEPARATOR: char = '.';
+    let (directive, additional_classnames) = match directive.split_once(CLASSNAME_SEPARATOR) {
+        None => (directive, Vec::new()),
+        Some((directive, additional_classnames)) => (
+            directive,
+            additional_classnames
+                .split(CLASSNAME_SEPARATOR)
+                .filter(|classname| !classname.is_empty())
+                .map(|classname| classname.to_owned())
+                .collect(),
+        ),
+    };
+
+    Ok(AdmonitionInfoRaw {
+        directive: directive.to_owned(),
+        title,
+        additional_classnames,
+    })
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn test_from_config_string() {
+        assert_eq!(
+            from_config_string("").unwrap(),
+            AdmonitionInfoRaw {
+                directive: "".to_owned(),
+                title: None,
+                additional_classnames: Vec::new(),
+            }
+        );
+        assert_eq!(
+            from_config_string(" ").unwrap(),
+            AdmonitionInfoRaw {
+                directive: "".to_owned(),
+                title: None,
+                additional_classnames: Vec::new(),
+            }
+        );
+        assert_eq!(
+            from_config_string("unknown").unwrap(),
+            AdmonitionInfoRaw {
+                directive: "unknown".to_owned(),
+                title: None,
+                additional_classnames: Vec::new(),
+            }
+        );
+        assert_eq!(
+            from_config_string("note").unwrap(),
+            AdmonitionInfoRaw {
+                directive: "note".to_owned(),
+                title: None,
+                additional_classnames: Vec::new(),
+            }
+        );
+        assert_eq!(
+            from_config_string("note.additional-classname").unwrap(),
+            AdmonitionInfoRaw {
+                directive: "note".to_owned(),
+                title: None,
+                additional_classnames: vec!["additional-classname".to_owned()]
+            }
+        );
+    }
+
+    #[test]
+    fn test_from_config_string_invalid_title_json() {
+        // Test invalid JSON title
+        assert_eq!(
+            from_config_string(r#"note "\""#).unwrap_err(),
+            "Error parsing JSON string: EOF while parsing a string at line 1 column 3".to_owned()
+        );
+    }
+
+    #[test]
+    fn test_from_config_string_v2_format() {
+        assert_eq!(
+            from_config_string(r#"note title="Custom""#).unwrap_err(),
+            "Invalid configuration string".to_owned()
+        );
+    }
+}

--- a/src/config/v2.rs
+++ b/src/config/v2.rs
@@ -1,0 +1,163 @@
+use super::AdmonitionInfoRaw;
+use once_cell::sync::Lazy;
+use regex::Regex;
+use serde::Deserialize;
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+struct AdmonitionInfoConfig {
+    #[serde(default)]
+    r#type: Option<String>,
+    #[serde(default)]
+    title: Option<String>,
+    #[serde(default)]
+    class: Option<String>,
+}
+
+/// Transform our config string into valid toml
+fn bare_key_value_pairs_to_toml(pairs: &str) -> String {
+    use regex::Captures;
+
+    static RX_BARE_KEY_ASSIGNMENT: Lazy<Regex> = Lazy::new(|| {
+        let bare_key = r#"[A-Za-z0-9_-]+"#;
+        Regex::new(&format!("(?:{bare_key}) *=")).expect("bare key assignment regex")
+    });
+
+    fn prefix_with_newline(captures: &Captures) -> String {
+        format!(
+            "\n{}",
+            captures
+                .get(0)
+                .expect("capture to have group zero")
+                .as_str()
+        )
+    }
+
+    RX_BARE_KEY_ASSIGNMENT
+        .replace_all(pairs, prefix_with_newline)
+        .into_owned()
+}
+
+/// Parse and return the config assuming v2 format.
+///
+/// Note that if an error occurs, a parsed struct that can be returned to
+/// show the error message will be returned.
+pub(crate) fn from_config_string(config_string: &str) -> Result<AdmonitionInfoRaw, String> {
+    let config_toml = bare_key_value_pairs_to_toml(config_string);
+    let config_toml = config_toml.trim();
+
+    let config: AdmonitionInfoConfig = match toml::from_str(config_toml) {
+        Ok(config) => config,
+        Err(error) => {
+            let original_error = Err(format!("TOML parsing error: {error}"));
+
+            // For ergonomic reasons, we allow users to specify the directive without
+            // a key. So if parsing fails initially, take the first line,
+            // use that as the directive, and reparse.
+            let (directive, config_toml) = match config_toml.split_once('\n') {
+                Some((directive, config_toml)) => (directive.trim(), config_toml),
+                None => (config_toml, ""),
+            };
+
+            static RX_DIRECTIVE: Lazy<Regex> =
+                Lazy::new(|| Regex::new(r#"^[A-Za-z0-9_-]+$"#).expect("directive regex"));
+
+            if !RX_DIRECTIVE.is_match(directive) {
+                return original_error;
+            }
+
+            let mut config: AdmonitionInfoConfig = match toml::from_str(config_toml) {
+                Ok(config) => config,
+                Err(_) => return original_error,
+            };
+            config.r#type = Some(directive.to_owned());
+            config
+        }
+    };
+    let additional_classnames = config
+        .class
+        .map(|class| {
+            class
+                .split(' ')
+                .filter(|classname| !classname.is_empty())
+                .map(|classname| classname.to_owned())
+                .collect()
+        })
+        .unwrap_or_default();
+    Ok(AdmonitionInfoRaw {
+        directive: config.r#type.unwrap_or_default(),
+        title: config.title,
+        additional_classnames,
+    })
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn test_from_config_string_v2() {
+        assert_eq!(
+            from_config_string("").unwrap(),
+            AdmonitionInfoRaw {
+                directive: "".to_owned(),
+                title: None,
+                additional_classnames: Vec::new(),
+            }
+        );
+        assert_eq!(
+            from_config_string(" ").unwrap(),
+            AdmonitionInfoRaw {
+                directive: "".to_owned(),
+                title: None,
+                additional_classnames: Vec::new(),
+            }
+        );
+        assert_eq!(
+            from_config_string(r#"type="note" class="additional classname" title="Никита""#)
+                .unwrap(),
+            AdmonitionInfoRaw {
+                directive: "note".to_owned(),
+                title: Some("Никита".to_owned()),
+                additional_classnames: vec!["additional".to_owned(), "classname".to_owned()]
+            }
+        );
+        // Specifying unknown keys is okay, as long as they're valid
+        assert_eq!(
+            from_config_string(r#"unkonwn="but valid toml""#).unwrap(),
+            AdmonitionInfoRaw {
+                directive: "".to_owned(),
+                title: None,
+                additional_classnames: Vec::new()
+            }
+        );
+        // Just directive is fine
+        assert_eq!(
+            from_config_string(r#"info"#).unwrap(),
+            AdmonitionInfoRaw {
+                directive: "info".to_owned(),
+                title: None,
+                additional_classnames: Vec::new()
+            }
+        );
+        // Directive plus toml config
+        assert_eq!(
+            from_config_string(r#"info title="Information""#).unwrap(),
+            AdmonitionInfoRaw {
+                directive: "info".to_owned(),
+                title: Some("Information".to_owned()),
+                additional_classnames: Vec::new()
+            }
+        );
+        // Directive after toml config is an error
+        assert!(from_config_string(r#"title="Information" info"#).is_err());
+    }
+
+    #[test]
+    fn test_from_config_string_invalid_toml_value() {
+        assert_eq!(
+            from_config_string(r#"note titlel=""#).unwrap_err(),
+            "TOML parsing error: expected an equals, found a newline at line 1 column 6".to_owned()
+        );
+    }
+}

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,0 +1,39 @@
+use std::str::FromStr;
+
+#[derive(Debug, PartialEq)]
+pub(crate) enum Directive {
+    Note,
+    Abstract,
+    Info,
+    Tip,
+    Success,
+    Question,
+    Warning,
+    Failure,
+    Danger,
+    Bug,
+    Example,
+    Quote,
+}
+
+impl FromStr for Directive {
+    type Err = ();
+
+    fn from_str(string: &str) -> Result<Self, ()> {
+        match string {
+            "note" => Ok(Self::Note),
+            "abstract" | "summary" | "tldr" => Ok(Self::Abstract),
+            "info" | "todo" => Ok(Self::Info),
+            "tip" | "hint" | "important" => Ok(Self::Tip),
+            "success" | "check" | "done" => Ok(Self::Success),
+            "question" | "help" | "faq" => Ok(Self::Question),
+            "warning" | "caution" | "attention" => Ok(Self::Warning),
+            "failure" | "fail" | "missing" => Ok(Self::Failure),
+            "danger" | "error" => Ok(Self::Danger),
+            "bug" => Ok(Self::Bug),
+            "example" => Ok(Self::Example),
+            "quote" | "cite" => Ok(Self::Quote),
+            _ => Err(()),
+        }
+    }
+}


### PR DESCRIPTION
See #18 

Make the configuration of blocks more extensible, while remaining back compatible with existing configuration options.