### PR TITLE
feat: better bug output, option to fail mdbook build

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,19 @@ Alternatively, pin to a specific version for a reproducible installation:
 cargo install mdbook-admonish --vers "1.5.0" --locked
 ```
 
+#### Bail on error
+
+By default, if an adomnition is incorrectly configured, an error will be shown in the book.
+
+You can force it to break the build instead, with the following configuration:
+
+```toml
+[preprocessor.admonish]
+on_failure = "bail"
+```
+
+This may be useful for non-interative workflows.
+
 ### Semantic Versioning
 
 Guarantees provided are as follows:

--- a/book/src/overview.md
+++ b/book/src/overview.md
@@ -134,3 +134,11 @@ Will yield something like the following HTML, which you can then apply styles to
     ...
 </div>
 ```
+
+#### Invalid blocks
+
+If a rendering error occurs, an error will be rendered in the output:
+
+```admonish title="
+This block will error
+```

--- a/integration/expected/chapter_1_main.html
+++ b/integration/expected/chapter_1_main.html
@@ -25,4 +25,19 @@
 <p>No title, only body</p>
 </div>
 </div>
+<div id="admonition-error-rendering-admonishment" class="admonition bug">
+<div class="admonition-title">
+<a class="admonition-anchor-link" href="#admonition-error-rendering-admonishment">
+<p>Error rendering admonishment</p>
+</a>
+</div>
+<div>
+<p>Failed with: Invalid configuration string</p>
+<p>Original markdown input:</p>
+<pre><code>```admonish title=&quot;
+No title, only body
+```
+</code></pre>
+</div>
+</div>
 

--- a/integration/src/chapter_1.md
+++ b/integration/src/chapter_1.md
@@ -13,3 +13,7 @@ Simples
 ```admonish warning ""
 No title, only body
 ```
+
+```admonish title="
+No title, only body
+```

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -59,14 +59,8 @@ pub(crate) struct AdmonitionInfo {
 }
 
 impl AdmonitionInfo {
-    pub fn from_info_string(info_string: &str) -> Option<Self> {
-        AdmonitionInfoRaw::from_info_string(info_string).map(|result| {
-            result.map(Into::into).unwrap_or_else(|error| Self {
-                directive: Directive::Bug,
-                title: Some(error),
-                additional_classnames: Vec::new(),
-            })
-        })
+    pub fn from_info_string(info_string: &str) -> Option<Result<Self, String>> {
+        AdmonitionInfoRaw::from_info_string(info_string).map(|result| result.map(Into::into))
     }
 }
 


### PR DESCRIPTION
As part of testing #24, I wanted a way to see if a large amount of real configuration raised an error. This PR adds a bunch of nicer error handling, and the ability to fail CI from a script.