### PR TITLE
Add collapsible support

### DIFF
--- a/book/book.toml
+++ b/book/book.toml
@@ -9,7 +9,7 @@ title = "The mdbook-admonish book"
 
 [preprocessor.admonish]
 command = "mdbook-admonish"
-assets_version = "1.0.0" # do not edit: managed by `mdbook-admonish install`
+assets_version = "2.0.0" # do not edit: managed by `mdbook-admonish install`
 
 [output]
 

--- a/book/src/overview.md
+++ b/book/src/overview.md
@@ -135,6 +135,22 @@ Will yield something like the following HTML, which you can then apply styles to
 </div>
 ```
 
+#### Collapsible
+
+For a block to be initially collapsible, and then be openable, set `collapsible=true`:
+
+````
+```admonish collapsible=true
+Content will be hidden initially.
+```
+````
+
+Will yield something like the following HTML, which you can then apply styles to:
+
+```admonish collapsible=true
+Content will be hidden initially.
+```
+
 #### Invalid blocks
 
 If a rendering error occurs, an error will be rendered in the output:

--- a/compile_assets/scss/admonition.scss
+++ b/compile_assets/scss/admonition.scss
@@ -65,6 +65,8 @@ $admonitions: (
     --md-admonition-icon--#{nth($names, 1)}: 
       url("data:image/svg+xml;charset=utf-8,#{nth($props, 2)}");
   }
+  --md-details-icon:
+    url("data:image/svg+xml;charset=utf-8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path d='M8.59 16.58 13.17 12 8.59 7.41 10 6l6 6-6 6-1.41-1.42Z'/></svg>");
 }
 
 // ----------------------------------------------------------------------------
@@ -183,6 +185,30 @@ a.admonition-anchor-link {
   // Show anchor link on hover over title
   &:hover a.admonition-anchor-link {
     display: initial
+  }
+}
+
+summary.admonition-title {
+  details.admonition > &::after {
+    position: absolute;
+    top: .625em;
+    inset-inline-end: 1.6rem;
+    height: 2rem;
+    width: 2rem;
+    background-color: currentcolor;
+    mask-image: var(--md-details-icon);
+    -webkit-mask-image: var(--md-details-icon);
+    mask-repeat: no-repeat;
+    -webkit-mask-repeat: no-repeat;
+    mask-size: contain;
+    -webkit-mask-size: contain;
+    content: "";
+    transform: rotate(0deg);
+    transition: transform .25s;
+  }
+
+  details[open].admonition > &::after {
+    transform: rotate(90deg);
   }
 }
 

--- a/integration/expected/chapter_1_main.html
+++ b/integration/expected/chapter_1_main.html
@@ -37,4 +37,13 @@ No title, only body
 </code></pre>
 </div>
 </div>
+<details id="admonition-note-1" class="admonition note">
+<summary class="admonition-title">
+<p>Note</p>
+<p><a class="admonition-anchor-link" href="#admonition-note-1"></a></p>
+</summary>
+<div>
+<p>Hidden on load</p>
+</div>
+</details>
 

--- a/integration/src/chapter_1.md
+++ b/integration/src/chapter_1.md
@@ -17,3 +17,7 @@ No title, only body
 ```admonish title="
 No title, only body
 ```
+
+```admonish collapsible=true
+Hidden on load
+```

--- a/src/bin/assets/mdbook-admonish.css
+++ b/src/bin/assets/mdbook-admonish.css
@@ -24,6 +24,8 @@
     url("data:image/svg+xml;charset=utf-8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path d='M7 13v-2h14v2H7m0 6v-2h14v2H7M7 7V5h14v2H7M3 8V5H2V4h2v4H3m-1 9v-1h3v4H2v-1h2v-.5H3v-1h1V17H2m2.25-7a.75.75 0 0 1 .75.75c0 .2-.08.39-.21.52L3.12 13H5v1H2v-.92L4 11H2v-1h2.25z'/></svg>");
   --md-admonition-icon--quote:
     url("data:image/svg+xml;charset=utf-8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path d='M14 17h3l2-4V7h-6v6h3M6 17h3l2-4V7H5v6h3l-2 4z'/></svg>");
+  --md-details-icon:
+    url("data:image/svg+xml;charset=utf-8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path d='M8.59 16.58 13.17 12 8.59 7.41 10 6l6 6-6 6-1.41-1.42Z'/></svg>");
 }
 
 :is(.admonition) {
@@ -106,6 +108,27 @@ html :is(.admonition-title, summary):last-child {
 }
 :is(.admonition-title, summary):hover a.admonition-anchor-link {
   display: initial;
+}
+
+details.admonition > summary.admonition-title::after {
+  position: absolute;
+  top: 0.625em;
+  inset-inline-end: 1.6rem;
+  height: 2rem;
+  width: 2rem;
+  background-color: currentcolor;
+  mask-image: var(--md-details-icon);
+  -webkit-mask-image: var(--md-details-icon);
+  mask-repeat: no-repeat;
+  -webkit-mask-repeat: no-repeat;
+  mask-size: contain;
+  -webkit-mask-size: contain;
+  content: "";
+  transform: rotate(0deg);
+  transition: transform 0.25s;
+}
+details[open].admonition > summary.admonition-title::after {
+  transform: rotate(90deg);
 }
 
 :is(.admonition):is(.note) {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -9,6 +9,7 @@ pub(crate) struct AdmonitionInfoRaw {
     directive: String,
     title: Option<String>,
     additional_classnames: Vec<String>,
+    collapsible: bool,
 }
 
 /// Extract the remaining info string, if this is an admonition block.
@@ -56,6 +57,7 @@ pub(crate) struct AdmonitionInfo {
     pub directive: Directive,
     pub title: Option<String>,
     pub additional_classnames: Vec<String>,
+    pub collapsible: bool,
 }
 
 impl AdmonitionInfo {
@@ -70,6 +72,7 @@ impl From<AdmonitionInfoRaw> for AdmonitionInfo {
             directive: raw_directive,
             title,
             additional_classnames,
+            collapsible,
         } = other;
         let (directive, title) = match (Directive::from_str(&raw_directive), title) {
             (Ok(directive), None) => (directive, ucfirst(&raw_directive)),
@@ -83,6 +86,7 @@ impl From<AdmonitionInfoRaw> for AdmonitionInfo {
             directive,
             title,
             additional_classnames,
+            collapsible,
         }
     }
 }
@@ -116,7 +120,8 @@ mod test {
             AdmonitionInfoRaw {
                 directive: "note".to_owned(),
                 title: None,
-                additional_classnames: vec!["additional-classname".to_owned()]
+                additional_classnames: vec!["additional-classname".to_owned()],
+                collapsible: false,
             }
         );
         // v2 syntax is supported
@@ -128,6 +133,7 @@ mod test {
                 directive: "question".to_owned(),
                 title: Some("Custom Title".to_owned()),
                 additional_classnames: Vec::new(),
+                collapsible: false,
             }
         );
     }
@@ -139,11 +145,13 @@ mod test {
                 directive: " ".to_owned(),
                 title: None,
                 additional_classnames: Vec::new(),
+                collapsible: false,
             }),
             AdmonitionInfo {
                 directive: Directive::Note,
                 title: Some("Note".to_owned()),
                 additional_classnames: Vec::new(),
+                collapsible: false,
             }
         );
     }

--- a/src/config/v1.rs
+++ b/src/config/v1.rs
@@ -53,6 +53,7 @@ pub(crate) fn from_config_string(config_string: &str) -> Result<AdmonitionInfoRa
         directive: directive.to_owned(),
         title,
         additional_classnames,
+        collapsible: false,
     })
 }
 
@@ -69,6 +70,7 @@ mod test {
                 directive: "".to_owned(),
                 title: None,
                 additional_classnames: Vec::new(),
+                collapsible: false,
             }
         );
         assert_eq!(
@@ -77,6 +79,7 @@ mod test {
                 directive: "".to_owned(),
                 title: None,
                 additional_classnames: Vec::new(),
+                collapsible: false,
             }
         );
         assert_eq!(
@@ -85,6 +88,7 @@ mod test {
                 directive: "unknown".to_owned(),
                 title: None,
                 additional_classnames: Vec::new(),
+                collapsible: false,
             }
         );
         assert_eq!(
@@ -93,6 +97,7 @@ mod test {
                 directive: "note".to_owned(),
                 title: None,
                 additional_classnames: Vec::new(),
+                collapsible: false,
             }
         );
         assert_eq!(
@@ -100,7 +105,8 @@ mod test {
             AdmonitionInfoRaw {
                 directive: "note".to_owned(),
                 title: None,
-                additional_classnames: vec!["additional-classname".to_owned()]
+                additional_classnames: vec!["additional-classname".to_owned()],
+                collapsible: false,
             }
         );
     }

--- a/src/config/v2.rs
+++ b/src/config/v2.rs
@@ -11,6 +11,8 @@ struct AdmonitionInfoConfig {
     title: Option<String>,
     #[serde(default)]
     class: Option<String>,
+    #[serde(default)]
+    collapsible: bool,
 }
 
 /// Transform our config string into valid toml
@@ -87,6 +89,7 @@ pub(crate) fn from_config_string(config_string: &str) -> Result<AdmonitionInfoRa
         directive: config.r#type.unwrap_or_default(),
         title: config.title,
         additional_classnames,
+        collapsible: config.collapsible,
     })
 }
 
@@ -103,6 +106,7 @@ mod test {
                 directive: "".to_owned(),
                 title: None,
                 additional_classnames: Vec::new(),
+                collapsible: false,
             }
         );
         assert_eq!(
@@ -111,6 +115,7 @@ mod test {
                 directive: "".to_owned(),
                 title: None,
                 additional_classnames: Vec::new(),
+                collapsible: false,
             }
         );
         assert_eq!(
@@ -119,7 +124,8 @@ mod test {
             AdmonitionInfoRaw {
                 directive: "note".to_owned(),
                 title: Some("Никита".to_owned()),
-                additional_classnames: vec!["additional".to_owned(), "classname".to_owned()]
+                additional_classnames: vec!["additional".to_owned(), "classname".to_owned()],
+                collapsible: false,
             }
         );
         // Specifying unknown keys is okay, as long as they're valid
@@ -128,7 +134,8 @@ mod test {
             AdmonitionInfoRaw {
                 directive: "".to_owned(),
                 title: None,
-                additional_classnames: Vec::new()
+                additional_classnames: Vec::new(),
+                collapsible: false,
             }
         );
         // Just directive is fine
@@ -137,7 +144,8 @@ mod test {
             AdmonitionInfoRaw {
                 directive: "info".to_owned(),
                 title: None,
-                additional_classnames: Vec::new()
+                additional_classnames: Vec::new(),
+                collapsible: false,
             }
         );
         // Directive plus toml config
@@ -146,7 +154,8 @@ mod test {
             AdmonitionInfoRaw {
                 directive: "info".to_owned(),
                 title: Some("Information".to_owned()),
-                additional_classnames: Vec::new()
+                additional_classnames: Vec::new(),
+                collapsible: false,
             }
         );
         // Directive after toml config is an error


### PR DESCRIPTION
This Pull Request adds collapsible admonition support, as described in <https://github.com/tommilligan/mdbook-admonish/issues/18>.

In its current state, this implementation has 2 shortcomings that I'm not sure how to overcome:
1. The CSS could be modified to make the arrow look slightly better.
2. The links to the admonition titles interfere with the open/close interaction. Clicking on the title doesn't open the box, which is counter-intuitive.