### PR TITLE
feat: add default title option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Added
+
+- User can set book-wide default for title and collapsible properties ([#84](https://github.com/tommilligan/mdbook-admonish/pull/84)), thanks to [@ShaunSHamilton](https://github.com/ShaunSHamilton)
+
 ### Changed
 
 - MSRV (minimum supported rust version) is now 1.64.0 for clap v4 ([#79](https://github.com/tommilligan/mdbook-admonish/pull/79))
@@ -27,7 +31,7 @@
 ### Added
 
 - Support key/value configuration ([#24](https://github.com/tommilligan/mdbook-admonish/pull/24), thanks [@gggto](https://github.com/gggto) and [@schungx](https://github.com/schungx) for design input)
-- Support collapsiable admonition bodies ([#26](https://github.com/tommilligan/mdbook-admonish/pull/26), thanks [@gggto](https://github.com/gggto) for the suggestion and implementation!)
+- Support collapsible admonition bodies ([#26](https://github.com/tommilligan/mdbook-admonish/pull/26), thanks [@gggto](https://github.com/gggto) for the suggestion and implementation!)
 - Make anchor links hoverable ([#27](https://github.com/tommilligan/mdbook-admonish/pull/27))
 - Better handling for misconfigured admonitions ([#25](https://github.com/tommilligan/mdbook-admonish/pull/25))
   - Nicer in-book error messages

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -6,7 +6,7 @@ mod v2;
 /// This structure represents the configuration the user must provide in each
 /// instance.
 #[derive(Debug, PartialEq)]
-pub(crate) struct AdmonitionInfoRaw {
+pub(crate) struct InstanceConfig {
     pub(crate) directive: String,
     pub(crate) title: Option<String>,
     pub(crate) additional_classnames: Vec<String>,
@@ -28,10 +28,10 @@ fn admonition_config_string(info_string: &str) -> Option<&str> {
     }
 }
 
-impl AdmonitionInfoRaw {
+impl InstanceConfig {
     /// Returns:
     /// - `None` if this is not an `admonish` block.
-    /// - `Some(AdmonitionInfoRaw)` if this is an `admonish` block
+    /// - `Some(InstanceConfig)` if this is an `admonish` block
     pub fn from_info_string(info_string: &str) -> Option<Result<Self, String>> {
         let config_string = admonition_config_string(info_string)?;
 
@@ -41,15 +41,13 @@ impl AdmonitionInfoRaw {
             Err(config) => config,
         };
 
-        Some(
-            if let Ok(info_raw) = v1::from_config_string(config_string) {
-                // If we succeed at parsing v1, return that.
-                Ok(info_raw)
-            } else {
-                // Otherwise return our v2 error.
-                Err(config_v2_error)
-            },
-        )
+        Some(if let Ok(config) = v1::from_config_string(config_string) {
+            // If we succeed at parsing v1, return that.
+            Ok(config)
+        } else {
+            // Otherwise return our v2 error.
+            Err(config_v2_error)
+        })
     }
 }
 
@@ -61,14 +59,14 @@ mod test {
     #[test]
     fn test_from_info_string() {
         // Not admonition blocks
-        assert_eq!(AdmonitionInfoRaw::from_info_string(""), None);
-        assert_eq!(AdmonitionInfoRaw::from_info_string("adm"), None);
+        assert_eq!(InstanceConfig::from_info_string(""), None);
+        assert_eq!(InstanceConfig::from_info_string("adm"), None);
         // v1 syntax is supported back compatibly
         assert_eq!(
-            AdmonitionInfoRaw::from_info_string("admonish note.additional-classname")
+            InstanceConfig::from_info_string("admonish note.additional-classname")
                 .unwrap()
                 .unwrap(),
-            AdmonitionInfoRaw {
+            InstanceConfig {
                 directive: "note".to_owned(),
                 title: None,
                 additional_classnames: vec!["additional-classname".to_owned()],
@@ -77,10 +75,10 @@ mod test {
         );
         // v2 syntax is supported
         assert_eq!(
-            AdmonitionInfoRaw::from_info_string(r#"admonish title="Custom Title" type="question""#)
+            InstanceConfig::from_info_string(r#"admonish title="Custom Title" type="question""#)
                 .unwrap()
                 .unwrap(),
-            AdmonitionInfoRaw {
+            InstanceConfig {
                 directive: "question".to_owned(),
                 title: Some("Custom Title".to_owned()),
                 additional_classnames: Vec::new(),

--- a/src/config/v1.rs
+++ b/src/config/v1.rs
@@ -1,8 +1,8 @@
-use super::AdmonitionInfoRaw;
+use super::InstanceConfig;
 use once_cell::sync::Lazy;
 use regex::Regex;
 
-pub(crate) fn from_config_string(config_string: &str) -> Result<AdmonitionInfoRaw, String> {
+pub(crate) fn from_config_string(config_string: &str) -> Result<InstanceConfig, String> {
     let config_string = config_string.trim();
 
     static RX_CONFIG_STRING_V1: Lazy<Regex> = Lazy::new(|| {
@@ -49,7 +49,7 @@ pub(crate) fn from_config_string(config_string: &str) -> Result<AdmonitionInfoRa
         ),
     };
 
-    Ok(AdmonitionInfoRaw {
+    Ok(InstanceConfig {
         directive: directive.to_owned(),
         title,
         additional_classnames,
@@ -66,7 +66,7 @@ mod test {
     fn test_from_config_string() {
         assert_eq!(
             from_config_string("").unwrap(),
-            AdmonitionInfoRaw {
+            InstanceConfig {
                 directive: "".to_owned(),
                 title: None,
                 additional_classnames: Vec::new(),
@@ -75,7 +75,7 @@ mod test {
         );
         assert_eq!(
             from_config_string(" ").unwrap(),
-            AdmonitionInfoRaw {
+            InstanceConfig {
                 directive: "".to_owned(),
                 title: None,
                 additional_classnames: Vec::new(),
@@ -84,7 +84,7 @@ mod test {
         );
         assert_eq!(
             from_config_string("unknown").unwrap(),
-            AdmonitionInfoRaw {
+            InstanceConfig {
                 directive: "unknown".to_owned(),
                 title: None,
                 additional_classnames: Vec::new(),
@@ -93,7 +93,7 @@ mod test {
         );
         assert_eq!(
             from_config_string("note").unwrap(),
-            AdmonitionInfoRaw {
+            InstanceConfig {
                 directive: "note".to_owned(),
                 title: None,
                 additional_classnames: Vec::new(),
@@ -102,7 +102,7 @@ mod test {
         );
         assert_eq!(
             from_config_string("note.additional-classname").unwrap(),
-            AdmonitionInfoRaw {
+            InstanceConfig {
                 directive: "note".to_owned(),
                 title: None,
                 additional_classnames: vec!["additional-classname".to_owned()],

--- a/src/config/v1.rs
+++ b/src/config/v1.rs
@@ -53,7 +53,7 @@ pub(crate) fn from_config_string(config_string: &str) -> Result<AdmonitionInfoRa
         directive: directive.to_owned(),
         title,
         additional_classnames,
-        collapsible: false,
+        collapsible: None,
     })
 }
 
@@ -70,7 +70,7 @@ mod test {
                 directive: "".to_owned(),
                 title: None,
                 additional_classnames: Vec::new(),
-                collapsible: false,
+                collapsible: None,
             }
         );
         assert_eq!(
@@ -79,7 +79,7 @@ mod test {
                 directive: "".to_owned(),
                 title: None,
                 additional_classnames: Vec::new(),
-                collapsible: false,
+                collapsible: None,
             }
         );
         assert_eq!(
@@ -88,7 +88,7 @@ mod test {
                 directive: "unknown".to_owned(),
                 title: None,
                 additional_classnames: Vec::new(),
-                collapsible: false,
+                collapsible: None,
             }
         );
         assert_eq!(
@@ -97,7 +97,7 @@ mod test {
                 directive: "note".to_owned(),
                 title: None,
                 additional_classnames: Vec::new(),
-                collapsible: false,
+                collapsible: None,
             }
         );
         assert_eq!(
@@ -106,7 +106,7 @@ mod test {
                 directive: "note".to_owned(),
                 title: None,
                 additional_classnames: vec!["additional-classname".to_owned()],
-                collapsible: false,
+                collapsible: None,
             }
         );
     }

--- a/src/config/v2.rs
+++ b/src/config/v2.rs
@@ -12,7 +12,7 @@ struct AdmonitionInfoConfig {
     #[serde(default)]
     class: Option<String>,
     #[serde(default)]
-    collapsible: bool,
+    collapsible: Option<bool>,
 }
 
 /// Transform our config string into valid toml
@@ -106,7 +106,7 @@ mod test {
                 directive: "".to_owned(),
                 title: None,
                 additional_classnames: Vec::new(),
-                collapsible: false,
+                collapsible: None,
             }
         );
         assert_eq!(
@@ -115,17 +115,19 @@ mod test {
                 directive: "".to_owned(),
                 title: None,
                 additional_classnames: Vec::new(),
-                collapsible: false,
+                collapsible: None,
             }
         );
         assert_eq!(
-            from_config_string(r#"type="note" class="additional classname" title="Никита""#)
-                .unwrap(),
+            from_config_string(
+                r#"type="note" class="additional classname" title="Никита" collapsible=true"#
+            )
+            .unwrap(),
             AdmonitionInfoRaw {
                 directive: "note".to_owned(),
                 title: Some("Никита".to_owned()),
                 additional_classnames: vec!["additional".to_owned(), "classname".to_owned()],
-                collapsible: false,
+                collapsible: Some(true),
             }
         );
         // Specifying unknown keys is okay, as long as they're valid
@@ -135,7 +137,7 @@ mod test {
                 directive: "".to_owned(),
                 title: None,
                 additional_classnames: Vec::new(),
-                collapsible: false,
+                collapsible: None,
             }
         );
         // Just directive is fine
@@ -145,17 +147,17 @@ mod test {
                 directive: "info".to_owned(),
                 title: None,
                 additional_classnames: Vec::new(),
-                collapsible: false,
+                collapsible: None,
             }
         );
         // Directive plus toml config
         assert_eq!(
-            from_config_string(r#"info title="Information""#).unwrap(),
+            from_config_string(r#"info title="Information" collapsible=false"#).unwrap(),
             AdmonitionInfoRaw {
                 directive: "info".to_owned(),
                 title: Some("Information".to_owned()),
                 additional_classnames: Vec::new(),
-                collapsible: false,
+                collapsible: Some(false),
             }
         );
         // Directive after toml config is an error

--- a/src/config/v2.rs
+++ b/src/config/v2.rs
@@ -1,10 +1,10 @@
-use super::AdmonitionInfoRaw;
+use super::InstanceConfig;
 use once_cell::sync::Lazy;
 use regex::Regex;
 use serde::Deserialize;
 
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
-struct AdmonitionInfoConfig {
+struct UserInput {
     #[serde(default)]
     r#type: Option<String>,
     #[serde(default)]
@@ -43,11 +43,11 @@ fn bare_key_value_pairs_to_toml(pairs: &str) -> String {
 ///
 /// Note that if an error occurs, a parsed struct that can be returned to
 /// show the error message will be returned.
-pub(crate) fn from_config_string(config_string: &str) -> Result<AdmonitionInfoRaw, String> {
+pub(crate) fn from_config_string(config_string: &str) -> Result<InstanceConfig, String> {
     let config_toml = bare_key_value_pairs_to_toml(config_string);
     let config_toml = config_toml.trim();
 
-    let config: AdmonitionInfoConfig = match toml::from_str(config_toml) {
+    let config: UserInput = match toml::from_str(config_toml) {
         Ok(config) => config,
         Err(error) => {
             let original_error = Err(format!("TOML parsing error: {error}"));
@@ -67,7 +67,7 @@ pub(crate) fn from_config_string(config_string: &str) -> Result<AdmonitionInfoRa
                 return original_error;
             }
 
-            let mut config: AdmonitionInfoConfig = match toml::from_str(config_toml) {
+            let mut config: UserInput = match toml::from_str(config_toml) {
                 Ok(config) => config,
                 Err(_) => return original_error,
             };
@@ -85,7 +85,7 @@ pub(crate) fn from_config_string(config_string: &str) -> Result<AdmonitionInfoRa
                 .collect()
         })
         .unwrap_or_default();
-    Ok(AdmonitionInfoRaw {
+    Ok(InstanceConfig {
         directive: config.r#type.unwrap_or_default(),
         title: config.title,
         additional_classnames,
@@ -102,7 +102,7 @@ mod test {
     fn test_from_config_string_v2() {
         assert_eq!(
             from_config_string("").unwrap(),
-            AdmonitionInfoRaw {
+            InstanceConfig {
                 directive: "".to_owned(),
                 title: None,
                 additional_classnames: Vec::new(),
@@ -111,7 +111,7 @@ mod test {
         );
         assert_eq!(
             from_config_string(" ").unwrap(),
-            AdmonitionInfoRaw {
+            InstanceConfig {
                 directive: "".to_owned(),
                 title: None,
                 additional_classnames: Vec::new(),
@@ -123,7 +123,7 @@ mod test {
                 r#"type="note" class="additional classname" title="Никита" collapsible=true"#
             )
             .unwrap(),
-            AdmonitionInfoRaw {
+            InstanceConfig {
                 directive: "note".to_owned(),
                 title: Some("Никита".to_owned()),
                 additional_classnames: vec!["additional".to_owned(), "classname".to_owned()],
@@ -133,7 +133,7 @@ mod test {
         // Specifying unknown keys is okay, as long as they're valid
         assert_eq!(
             from_config_string(r#"unkonwn="but valid toml""#).unwrap(),
-            AdmonitionInfoRaw {
+            InstanceConfig {
                 directive: "".to_owned(),
                 title: None,
                 additional_classnames: Vec::new(),
@@ -143,7 +143,7 @@ mod test {
         // Just directive is fine
         assert_eq!(
             from_config_string(r#"info"#).unwrap(),
-            AdmonitionInfoRaw {
+            InstanceConfig {
                 directive: "info".to_owned(),
                 title: None,
                 additional_classnames: Vec::new(),
@@ -153,7 +153,7 @@ mod test {
         // Directive plus toml config
         assert_eq!(
             from_config_string(r#"info title="Information" collapsible=false"#).unwrap(),
-            AdmonitionInfoRaw {
+            InstanceConfig {
                 directive: "info".to_owned(),
                 title: Some("Information".to_owned()),
                 additional_classnames: Vec::new(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@ mod resolve;
 mod types;
 
 use crate::{
-    resolve::AdmonitionInfo,
+    resolve::AdmonitionMeta,
     types::{AdmonitionDefaults, Directive},
 };
 
@@ -151,8 +151,8 @@ struct Admonition<'a> {
 }
 
 impl<'a> Admonition<'a> {
-    pub fn new(info: AdmonitionInfo, content: &'a str) -> Self {
-        let AdmonitionInfo {
+    pub fn new(info: AdmonitionMeta, content: &'a str) -> Self {
+        let AdmonitionMeta {
             directive,
             title,
             additional_classnames,
@@ -255,7 +255,7 @@ fn parse_admonition<'a>(
     content: &'a str,
     on_failure: OnFailure,
 ) -> Option<MdbookResult<Admonition<'a>>> {
-    let info = AdmonitionInfo::from_info_string(info_string, admonition_defaults)?;
+    let info = AdmonitionMeta::from_info_string(info_string, admonition_defaults)?;
     let info = match info {
         Ok(info) => info,
         // FIXME return error messages to break build if configured

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -1,0 +1,92 @@
+use crate::config::AdmonitionInfoRaw;
+use crate::types::{AdmonitionDefaults, Directive};
+use std::str::FromStr;
+
+/// All information required to render an admonition.
+///
+/// i.e. all configured options have been resolved at this point.
+#[derive(Debug, PartialEq)]
+pub(crate) struct AdmonitionInfo {
+    pub directive: Directive,
+    pub title: String,
+    pub additional_classnames: Vec<String>,
+    pub collapsible: bool,
+}
+
+impl AdmonitionInfo {
+    pub fn from_info_string(
+        info_string: &str,
+        defaults: &AdmonitionDefaults,
+    ) -> Option<Result<Self, String>> {
+        AdmonitionInfoRaw::from_info_string(info_string)
+            .map(|raw| raw.map(|raw| Self::resolve(raw, defaults)))
+    }
+
+    /// Combine the per-admonition configuration with global defaults (and
+    /// other logic) to resolve the values needed for rendering.
+    fn resolve(raw: AdmonitionInfoRaw, defaults: &AdmonitionDefaults) -> Self {
+        let AdmonitionInfoRaw {
+            directive: raw_directive,
+            title,
+            additional_classnames,
+            collapsible,
+        } = raw;
+
+        // Use values from block, else load default value
+        let title = title.or_else(|| defaults.title.clone());
+        let collapsible = collapsible.or(defaults.collapsible).unwrap_or_default();
+
+        // Load the directive (and title, if one still not given)
+        let (directive, title) = match (Directive::from_str(&raw_directive), title) {
+            (Ok(directive), None) => (directive, ucfirst(&raw_directive)),
+            (Err(_), None) => (Directive::Note, "Note".to_owned()),
+            (Ok(directive), Some(title)) => (directive, title),
+            (Err(_), Some(title)) => (Directive::Note, title),
+        };
+
+        Self {
+            directive,
+            title,
+            additional_classnames,
+            collapsible,
+        }
+    }
+}
+
+/// Make the first letter of `input` upppercase.
+///
+/// source: https://stackoverflow.com/a/38406885
+fn ucfirst(input: &str) -> String {
+    let mut chars = input.chars();
+    match chars.next() {
+        None => String::new(),
+        Some(f) => f.to_uppercase().collect::<String>() + chars.as_str(),
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn test_admonition_info_from_raw() {
+        assert_eq!(
+            AdmonitionInfo::resolve(
+                AdmonitionInfoRaw {
+                    directive: " ".to_owned(),
+                    title: None,
+                    additional_classnames: Vec::new(),
+                    collapsible: None,
+                },
+                &Default::default()
+            ),
+            AdmonitionInfo {
+                directive: Directive::Note,
+                title: "Note".to_owned(),
+                additional_classnames: Vec::new(),
+                collapsible: false,
+            }
+        );
+    }
+}

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -1,4 +1,4 @@
-use crate::config::AdmonitionInfoRaw;
+use crate::config::InstanceConfig;
 use crate::types::{AdmonitionDefaults, Directive};
 use std::str::FromStr;
 
@@ -6,26 +6,26 @@ use std::str::FromStr;
 ///
 /// i.e. all configured options have been resolved at this point.
 #[derive(Debug, PartialEq)]
-pub(crate) struct AdmonitionInfo {
+pub(crate) struct AdmonitionMeta {
     pub directive: Directive,
     pub title: String,
     pub additional_classnames: Vec<String>,
     pub collapsible: bool,
 }
 
-impl AdmonitionInfo {
+impl AdmonitionMeta {
     pub fn from_info_string(
         info_string: &str,
         defaults: &AdmonitionDefaults,
     ) -> Option<Result<Self, String>> {
-        AdmonitionInfoRaw::from_info_string(info_string)
+        InstanceConfig::from_info_string(info_string)
             .map(|raw| raw.map(|raw| Self::resolve(raw, defaults)))
     }
 
     /// Combine the per-admonition configuration with global defaults (and
     /// other logic) to resolve the values needed for rendering.
-    fn resolve(raw: AdmonitionInfoRaw, defaults: &AdmonitionDefaults) -> Self {
-        let AdmonitionInfoRaw {
+    fn resolve(raw: InstanceConfig, defaults: &AdmonitionDefaults) -> Self {
+        let InstanceConfig {
             directive: raw_directive,
             title,
             additional_classnames,
@@ -72,8 +72,8 @@ mod test {
     #[test]
     fn test_admonition_info_from_raw() {
         assert_eq!(
-            AdmonitionInfo::resolve(
-                AdmonitionInfoRaw {
+            AdmonitionMeta::resolve(
+                InstanceConfig {
                     directive: " ".to_owned(),
                     title: None,
                     additional_classnames: Vec::new(),
@@ -81,7 +81,7 @@ mod test {
                 },
                 &Default::default()
             ),
-            AdmonitionInfo {
+            AdmonitionMeta {
                 directive: Directive::Note,
                 title: "Note".to_owned(),
                 additional_classnames: Vec::new(),

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,4 +1,15 @@
+use serde::{Deserialize, Serialize};
 use std::str::FromStr;
+
+/// Book wide defaults that may be provided by the user.
+#[derive(Deserialize, Serialize, Debug, Default)]
+pub(crate) struct AdmonitionDefaults {
+    #[serde(default)]
+    pub(crate) title: Option<String>,
+
+    #[serde(default)]
+    pub(crate) collapsible: Option<bool>,
+}
 
 #[derive(Debug, PartialEq)]
 pub(crate) enum Directive {


### PR DESCRIPTION
**Adds:**

```toml
[preprocessor.admonish.default]
title = "..."
```

**Priorities:**

`explicit > default > directive`

What this means is any parse-able title given in the codeblock is taken as the desired. Then, any default given in the `book.toml`. Then, the directive is used as the fallback.

_My code is messier than I expected. So, feel free to be nit-picky about it_

Specifically, I am not sure how useful the return `Result<()>` from `Admonition::attach_defaults` is.

Closes #82 