### PR TITLE
fix: ensure error fences will always enclose block

### DIFF
--- a/src/parse.rs
+++ b/src/parse.rs
@@ -24,14 +24,35 @@ fn extract_admonish_body_start_index(content: &str) -> usize {
     }
 }
 
-fn extract_admonish_body_end_index(content: &str) -> usize {
+fn extract_admonish_body_end_index(content: &str) -> (usize, Fence) {
+    let fence_character = content.chars().rev().next().unwrap_or('`');
     let number_fence_characters = content
         .chars()
         .rev()
-        .position(|c| !(c == '`' || c == '~'))
+        .position(|c| c != fence_character)
         .unwrap_or_default();
+    let fence = Fence::new(fence_character, number_fence_characters);
 
-    content.len() - number_fence_characters
+    let index = content.len() - fence.length;
+    (index, fence)
+}
+
+#[derive(Debug, PartialEq)]
+pub(crate) struct Fence {
+    pub(crate) character: char,
+    pub(crate) length: usize,
+}
+
+impl Fence {
+    pub fn new(character: char, length: usize) -> Self {
+        Self { character, length }
+    }
+}
+
+#[derive(Debug, PartialEq)]
+pub(crate) struct Extracted<'a> {
+    pub(crate) body: &'a str,
+    pub(crate) fence: Fence,
 }
 
 /// Given the whole text content of the code fence, extract the body.
@@ -40,14 +61,15 @@ fn extract_admonish_body_end_index(content: &str) -> usize {
 /// but it's not really clear a good way of doing that.
 ///
 /// ref: https://spec.commonmark.org/0.30/#fenced-code-blocks
-pub(crate) fn extract_admonish_body(content: &str) -> &str {
+pub(crate) fn extract_admonish_body(content: &str) -> Extracted<'_> {
     let start_index = extract_admonish_body_start_index(content);
-    let end_index = extract_admonish_body_end_index(content);
+    let (end_index, fence) = extract_admonish_body_end_index(content);
 
     let admonish_content = &content[start_index..end_index];
     // The newline after a code block is technically optional, so we have to
     // trim it off dynamically.
-    admonish_content.trim_end()
+    let body = admonish_content.trim_end();
+    Extracted { body, fence }
 }
 
 #[cfg(test)]
@@ -73,13 +95,13 @@ mod test {
     #[test]
     fn test_extract_end() {
         for (text, expected) in [
-            ("\n```", 1),
+            ("\n```", (1, Fence::new('`', 3))),
             // different lengths
-            ("\n``````", 1),
-            ("\n~~~~", 1),
+            ("\n``````", (1, Fence::new('`', 6))),
+            ("\n~~~~", (1, Fence::new('~', 4))),
             // whitespace before fence end
-            ("\n   ```", 4),
-            ("content\n```", 8),
+            ("\n   ```", (4, Fence::new('`', 3))),
+            ("content\n```", (8, Fence::new('`', 3))),
         ] {
             let actual = extract_admonish_body_end_index(text);
             assert_eq!(actual, expected);
@@ -88,15 +110,36 @@ mod test {
 
     #[test]
     fn test_extract() {
+        fn content_fence(body: &'static str, character: char, length: usize) -> Extracted<'static> {
+            Extracted {
+                body,
+                fence: Fence::new(character, length),
+            }
+        }
         for (text, expected) in [
+            // empty
+            ("```\n```", content_fence("", '`', 3)),
             // standard
-            ("```admonish\ncontent\n```", "content"),
+            (
+                "```admonish\ncontent\n```",
+                content_fence("content", '`', 3),
+            ),
             // whitespace
-            ("```admonish  \n  content  \n  ```", "  content"),
+            (
+                "```admonish  \n  content  \n  ```",
+                content_fence("  content", '`', 3),
+            ),
             // longer
-            ("`````admonish\ncontent\n`````", "content"),
+            (
+                "``````admonish\ncontent\n``````",
+                content_fence("content", '`', 6),
+            ),
             // unequal
-            ("~~~admonish\ncontent\n~~~~~", "content"),
+            (
+                "~~~admonish\ncontent\n~~~~~",
+                // longer (end) fence returned
+                content_fence("content", '~', 5),
+            ),
         ] {
             let actual = extract_admonish_body(text);
             assert_eq!(actual, expected);


### PR DESCRIPTION
Relates to #87, #88

Ensure that when rendering an error message inside an admonition, we always generate a code fence that can wrap the inner fence.

Currently, for really long code fences, these would "escape" the enclosing block and break the formatting.