### PR TITLE
ci(deploy): Use Ubuntu 20.04 for building linux gnu target binaries

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,7 +21,11 @@ jobs:
             os: ubuntu-latest
             name: aarch64-unknown-linux-musl.tar.gz
           - target: x86_64-unknown-linux-gnu
-            os: ubuntu-latest
+            # Deliberately pinned to the same version `mdbook` uses to build
+            # binaries, so we use the same glibc version
+            #
+            # ref: https://github.com/rust-lang/mdBook/pull/1955
+            os: ubuntu-20.04
             name: x86_64-unknown-linux-gnu.tar.gz
           - target: x86_64-unknown-linux-musl
             os: ubuntu-latest


### PR DESCRIPTION
Same as rust-lang/mdBook#1955

Given that it will be used with mdBook, it makes sense to build it in the same version as the mdBook's CI.