### PR TITLE
feat: support admonitions inside list items

### DIFF
--- a/integration/expected/chapter_1_main.html
+++ b/integration/expected/chapter_1_main.html
@@ -90,4 +90,29 @@ let x = 20;
 <span class="boring">}</span></code></pre></pre>
 </div>
 </div>
+<p>In a list:</p>
+<ol>
+<li>
+<p>Thing one</p>
+<pre><code class="language-sh">Thing one
+</code></pre>
+</li>
+<li>
+<p>Thing two</p>
+<div id="admonition-note-4" class="admonition note">
+<div class="admonition-title">
+<p>Note</p>
+<p><a class="admonition-anchor-link" href="#admonition-note-4"></a></p>
+</div>
+<div>
+<p>Thing two</p>
+</div>
+</div>
+</li>
+<li>
+<p>Thing three</p>
+<pre><code class="language-sh">Thing three
+</code></pre>
+</li>
+</ol>
 

--- a/integration/src/chapter_1.md
+++ b/integration/src/chapter_1.md
@@ -41,3 +41,23 @@ let x = 10;
 let x = 20;
 ```
 ````
+
+In a list:
+
+1. Thing one
+
+   ```sh
+   Thing one
+   ```
+
+1. Thing two
+
+   ```admonish
+   Thing two
+   ```
+
+1. Thing three
+
+   ```sh
+   Thing three
+   ```

--- a/src/render.rs
+++ b/src/render.rs
@@ -31,10 +31,11 @@ pub(crate) struct Admonition<'a> {
     pub(crate) content: Cow<'a, str>,
     pub(crate) additional_classnames: Vec<String>,
     pub(crate) collapsible: bool,
+    pub(crate) indent: usize,
 }
 
 impl<'a> Admonition<'a> {
-    pub(crate) fn new(info: AdmonitionMeta, content: &'a str) -> Self {
+    pub(crate) fn new(info: AdmonitionMeta, content: &'a str, indent: usize) -> Self {
         let AdmonitionMeta {
             directive,
             title,
@@ -47,6 +48,7 @@ impl<'a> Admonition<'a> {
             content: Cow::Borrowed(content),
             additional_classnames,
             collapsible,
+            indent,
         }
     }
 
@@ -66,17 +68,18 @@ impl<'a> Admonition<'a> {
         let mut additional_class = Cow::Borrowed(self.directive.classname());
         let title = &self.title;
         let content = &self.content;
+        let indent = " ".repeat(self.indent);
 
         let title_block = if self.collapsible { "summary" } else { "div" };
 
         let title_html = if !title.is_empty() {
             Cow::Owned(format!(
-                r##"<{title_block} class="admonition-title">
-
-{title}
-
-<a class="admonition-anchor-link" href="#{ANCHOR_ID_PREFIX}-{anchor_id}"></a>
-</{title_block}>
+                r##"{indent}<{title_block} class="admonition-title">
+{indent}
+{indent}{title}
+{indent}
+{indent}<a class="admonition-anchor-link" href="#{ANCHOR_ID_PREFIX}-{anchor_id}"></a>
+{indent}</{title_block}>
 "##
             ))
         } else {
@@ -100,13 +103,13 @@ impl<'a> Admonition<'a> {
         //   rendered as markdown paragraphs.
         format!(
             r#"
-<{admonition_block} id="{ANCHOR_ID_PREFIX}-{anchor_id}" class="admonition {additional_class}">
-{title_html}<div>
-
-{content}
-
-</div>
-</{admonition_block}>"#,
+{indent}<{admonition_block} id="{ANCHOR_ID_PREFIX}-{anchor_id}" class="admonition {additional_class}">
+{title_html}{indent}<div>
+{indent}
+{indent}{content}
+{indent}
+{indent}</div>
+{indent}</{admonition_block}>"#,
         )
     }
 


### PR DESCRIPTION
Closes #123 

Maintains indent of admonition blocks from enclosing items. This allows the final rendered item to be embedded in a parent, such as a list:

![image](https://github.com/tommilligan/mdbook-admonish/assets/12255914/a757456c-f884-46e0-a29c-ea171b1d2ce1)

Prior to this, admonitions were transformed into HTML, but this HTML was not indented in the parent markdown. This led to the item not being considered a child of the containing markdown.