### PR TITLE
book: Add GitHub link

### DIFF
--- a/book/book.toml
+++ b/book/book.toml
@@ -4,6 +4,7 @@ language = "en"
 multilingual = false
 src = "src"
 title = "The mdbook-admonish book"
+git-repository-url = "https://github.com/tommilligan/mdbook-admonish"
 
 [preprocessor]
 


### PR DESCRIPTION
Hey, this is a nice mdBook addon. Wanted to chime in. I have some plans to contribute a bit, but I wanted to add a GitHub link to the official website for now.