### PR TITLE
remove serde kebab-case renaming for AdmonitionDefaults struct

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -5,7 +5,6 @@ use std::str::FromStr;
 
 /// Book wide defaults that may be provided by the user.
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize, Default)]
-#[serde(rename_all = "kebab-case")]
 pub(crate) struct AdmonitionDefaults {
     #[serde(default)]
     pub(crate) title: Option<String>,

--- a/src/types.rs
+++ b/src/types.rs
@@ -13,6 +13,9 @@ pub(crate) struct AdmonitionDefaults {
     pub(crate) collapsible: bool,
 
     #[serde(default)]
+    // For backwards compatibility, we support this field with kebab-case style
+    // naming, even though this was introduced in error.
+    #[serde(alias = "css-id-prefix")]
     pub(crate) css_id_prefix: Option<String>,
 }
 


### PR DESCRIPTION
The `AdmonitionDefaults` struct has an attribute to rename all fields in kebab case:
```rust
#[serde(rename_all = "kebab-case")]
pub(crate) struct AdmonitionDefaults {
    #[serde(default)]
    pub(crate) title: Option<String>,

    #[serde(default)]
    pub(crate) collapsible: bool,

    #[serde(default)]
    pub(crate) css_id_prefix: Option<String>,
}
```
This means that the `css_id_prefix` field must actually be declared as `css-id-prefix` in the *book.toml* file.
This is confusing because it is inconsistent with:

- the doc (e.g. [here](https://github.com/tommilligan/mdbook-admonish/blob/85fde44c0994214b894c5aa2c9814a6e4e7411fc/book/src/reference.md?plain=1#L41))
- the naming convention of other fields such as `on_failure` and `render_mode`.