### PR TITLE
fix: support toml values with equal sign

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Unreleased
+
+### Changed
+
+- Blocks should have key-value options separated by commas. Existing syntax remains is supported for back-compatibility. See [the documentation on Additional Options](https://tommilligan.github.io/mdbook-admonish/#additional-options) for more details ([#181](https://github.com/tommilligan/mdbook-admonish/pull/181))
+
+### Fixed
+
+- Titles contining `=` will now render correctly. Thanks to [@s00500](https://github.com/s00500) for the bug report! ([#181](https://github.com/tommilligan/mdbook-admonish/pull/181))
+
 ## v1.16.0
 
 ### Changed

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -2,3 +2,4 @@
 
 - [Overview](./overview.md)
 - [Reference](./reference.md)
+- [Examples](./examples.md)

--- a/book/src/examples.md
+++ b/book/src/examples.md
@@ -1,0 +1,15 @@
+# Examples
+
+## Combining multiple custom properties
+
+Note that the comma `,` is used to seperate custom options.
+
+````
+```admonish quote collapsible=true, title='A title that really <span style="color: #e70073">pops</span>'
+To really <b><span style="color: #e70073">grab</span></b> your reader's attention.
+```
+````
+
+```admonish quote collapsible=true, title='A title that really <span style="color: #e70073">pops</span>'
+To really <b><span style="color: #e70073">grab</span></b> your reader's attention.
+```

--- a/book/src/overview.md
+++ b/book/src/overview.md
@@ -78,14 +78,19 @@ You can also configure the build to fail loudly, by setting `on_failure = "bail"
 
 ### Additional Options
 
-You can pass additional options to each block. The options are structured as TOML key-value pairs.
+You can pass additional options to each block. Options are given like a [TOML Inline Table](https://toml.io/en/v1.0.0#inline-table), as key-value pairs separated by commas.
+
+`mdbook-admonish` parses options by wrapping your options in an inline table before parsing them, so please consult [The TOML Reference](https://toml.io) if you run into any syntax errors. Be aware that:
+
+- Key-value pairs must be separated with a comma `,`
+- TOML escapes must be escaped again - for instance, write `\"` as `\\"`.
+- For complex strings such as HTML, you may want to use a [literal string](https://toml.io/en/v1.0.0#string) to avoid complex escape sequences
 
 Note that some options can be passed globally, through the `default` section in `book.toml`. See the [configuration reference](./reference.md#booktoml-configuration) for more details.
 
 #### Custom title
 
-A custom title can be provided, contained in a double quoted TOML string.
-Note that TOML escapes must be escaped again - for instance, write `\"` as `\\"`.
+A custom title can be provided:
 
 ````
 ```admonish warning title="Data loss"
@@ -114,13 +119,13 @@ This will take a while, go and grab a drink of water.
 Markdown and HTML can be used in the inner content, as you'd expect:
 
 ````
-```admonish tip title="_Referencing_ and <i>dereferencing</i>"
+```admonish tip title='_Referencing_ and <i>dereferencing</i>'
 The opposite of *referencing* by using `&` is *dereferencing*, which is
 accomplished with the <span style="color: hotpink">dereference operator</span>, `*`.
 ```
 ````
 
-```admonish tip title="_Referencing_ and <i>dereferencing</i>"
+```admonish tip title='_Referencing_ and <i>dereferencing</i>'
 The opposite of *referencing* by using `&` is *dereferencing*, which is
 accomplished with the <span style="color: hotpink">dereference operator</span>, `*`.
 ```
@@ -148,7 +153,7 @@ print "Hello, world!"
 If you want to provide custom styling to a specific admonition, you can attach one or more custom classnames:
 
 ````
-```admonish note class="custom-0 custom-1"
+```admonish note title="Stylish", class="custom-0 custom-1"
 Styled with my custom CSS class.
 ```
 ````
@@ -173,7 +178,7 @@ with an appended number if multiple blocks would have the same id.
 Setting the `id` field will _ignore_ all other ids and the duplicate counter.
 
 ````
-```admonish info title="My Info" id="my-special-info"
+```admonish info title="My Info", id="my-special-info"
 Link to this block with `#my-special-info` instead of the default `#admonition-my-info`.
 ```
 ````
@@ -183,14 +188,14 @@ Link to this block with `#my-special-info` instead of the default `#admonition-m
 For a block to be initially collapsible, and then be openable, set `collapsible=true`:
 
 ````
-```admonish collapsible=true
+```admonish title="Sneaky", collapsible=true
 Content will be hidden initially.
 ```
 ````
 
 Will yield something like the following HTML, which you can then apply styles to:
 
-```admonish collapsible=true
+```admonish title="Sneaky", collapsible=true
 Content will be hidden initially.
 ```
 

--- a/integration/expected/chapter_1_main.html
+++ b/integration/expected/chapter_1_main.html
@@ -41,10 +41,10 @@
 <p>Failed with:</p>
 <pre><code class="language-log">'title=&quot;' is not a valid directive or TOML key-value pair.
 
-TOML parsing error: TOML parse error at line 1, column 8
+TOML parsing error: TOML parse error at line 1, column 21
   |
-1 | title=&quot;
-  |        ^
+1 | config = { title=&quot; }
+  |                     ^
 invalid basic string
 
 </code></pre>

--- a/src/config/toml_wrangling.rs
+++ b/src/config/toml_wrangling.rs
@@ -1,0 +1,44 @@
+use once_cell::sync::Lazy;
+use regex::Regex;
+use serde::Deserialize;
+use std::fmt::Display;
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+pub(crate) struct UserInput {
+    #[serde(default)]
+    pub r#type: Option<String>,
+    #[serde(default)]
+    pub title: Option<String>,
+    #[serde(default)]
+    pub id: Option<String>,
+    #[serde(default)]
+    pub class: Option<String>,
+    #[serde(default)]
+    pub collapsible: Option<bool>,
+}
+
+impl UserInput {
+    pub fn classnames(&self) -> Vec<String> {
+        self.class
+            .as_ref()
+            .map(|class| {
+                class
+                    .split(' ')
+                    .filter(|classname| !classname.is_empty())
+                    .map(|classname| classname.to_owned())
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+}
+
+pub(crate) static RX_DIRECTIVE: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r#"^[A-Za-z0-9_-]+$"#).expect("directive regex"));
+
+pub(crate) fn format_toml_parsing_error(error: impl Display) -> String {
+    format!("TOML parsing error: {error}")
+}
+
+pub(crate) fn format_invalid_directive(directive: &str, original_error: impl Display) -> String {
+    format!("'{directive}' is not a valid directive or TOML key-value pair.\n\n{original_error}")
+}

--- a/src/markdown.rs
+++ b/src/markdown.rs
@@ -598,10 +598,10 @@ Failed with:
 ```log
 'title="' is not a valid directive or TOML key-value pair.
 
-TOML parsing error: TOML parse error at line 1, column 8
+TOML parsing error: TOML parse error at line 1, column 21
   |
-1 | title="
-  |        ^
+1 | config = { title=" }
+  |                     ^
 invalid basic string
 
 ```
@@ -891,6 +891,39 @@ Check Mark
 <div>
 
 A simple admonition.
+
+</div>
+</div>
+Text
+"##;
+
+        assert_eq!(expected, prep(content));
+    }
+
+    #[test]
+    fn title_and_content_with_html() {
+        // Note that we use toml literal (single quoted) strings here
+        // and the fact we have an equals sign in the value does not cause
+        // us to break (because we're using v3 syntax, not v2)
+        let content = r#"# Chapter
+```admonish success title='Check <span class="emphasis">Mark</span>'
+A <span class="emphasis">simple</span> admonition.
+```
+Text
+"#;
+
+        let expected = r##"# Chapter
+
+<div id="admonition-check-mark" class="admonition admonish-success">
+<div class="admonition-title">
+
+Check <span class="emphasis">Mark</span>
+
+<a class="admonition-anchor-link" href="#admonition-check-mark"></a>
+</div>
+<div>
+
+A <span class="emphasis">simple</span> admonition.
 
 </div>
 </div>


### PR DESCRIPTION
Closes #179 

The v2 config format is not suitable for parsing complex toml values, specifically containing `=` values. This is due to the pre-parsing wrangling to marshal key-value pairs into a valid TOML format using `=` as a marker for TOML keys, when in fact it can appear in values too.

To fix this, introduce the new v3 config format which uses the [TOML Inline Table](https://toml.io/en/v1.0.0#inline-table) syntax to support this natively.

This PR adds the config back-compatibly, falling back to v2 (and v1) if parsing with the new format fails. It also updates all docs/examples to use the new comma separated format where appropriate.