### PR TITLE
Semantic & a11y suggestions

### DIFF
--- a/src/render.rs
+++ b/src/render.rs
@@ -87,7 +87,7 @@ impl<'a> Admonition<'a> {
         //   rendered as markdown paragraphs.
         format!(
             r#"
-{indent}<{admonition_block} id="{anchor_id}" class="admonition {additional_class}">
+{indent}<{admonition_block} role="note" id="{anchor_id}" class="admonition {additional_class}">
 {title_html}{indent}<div>
 {indent}
 {indent}{content}

--- a/src/render.rs
+++ b/src/render.rs
@@ -62,7 +62,9 @@ impl<'a> Admonition<'a> {
             Cow::Owned(format!(
                 r##"{indent}<{title_block} class="admonition-title">
 {indent}
+{indent}<div id="at_{anchor_id}">
 {indent}{title}
+{indent}</div>
 {indent}
 {indent}<a class="admonition-anchor-link" href="#{anchor_id}"></a>
 {indent}</{title_block}>
@@ -87,7 +89,7 @@ impl<'a> Admonition<'a> {
         //   rendered as markdown paragraphs.
         format!(
             r#"
-{indent}<{admonition_block} role="note" id="{anchor_id}" class="admonition {additional_class}">
+{indent}<{admonition_block} role="note" id="{anchor_id}" class="admonition {additional_class}" aria-labelledby="at_{anchor_id}">
 {title_html}{indent}<div>
 {indent}
 {indent}{content}


### PR DESCRIPTION
While I don’t like overloading code blocks (or blockquotes) for callouts/admonitions this library is widely used to solve the lack of a feature in the Markdown spec for technical documentation. I have [written about the topics of callouts](https://toast.al/posts/softwarecraft/2023-08-29_semantic-markup-for-callouts/) & I notice this plugin’s output isn’t covering HTML semantic roles or ARIA for accessibility. These are my suggestions.

Should be reviewable commit by commit. Either commit may be dropped or modified by the maintainer for the patchset.

[^1]

[^1]: Please consider [giving up MS GitHub](https://sfconservancy.org/GiveUpGitHub/) or offering a non-proprietary, non-US-corporate-controlled mirror for this free software project. I wish to delete this Microsoft account in the future, but I need more projects like this to support alternative methods to send patches & contribute.