### PR TITLE
feat: add aria attributes to block

### DIFF
--- a/integration/expected/chapter_1_main.html
+++ b/integration/expected/chapter_1_main.html
@@ -1,41 +1,49 @@
                         <h1 id="chapter-1"><a class="header" href="#chapter-1">Chapter 1</a></h1>
-<div id="admonition-what-is-this" class="admonition admonish-abstract">
+<div id="admonition-what-is-this" class="admonition admonish-abstract" role="note" aria-labelledby="admonition-what-is-this-title">
 <div class="admonition-title">
+<div id="admonition-what-is-this-title">
 <p>What <i>is</i> this?</p>
-<p><a class="admonition-anchor-link" href="#admonition-what-is-this"></a></p>
+</div>
+<a class="admonition-anchor-link" href="#admonition-what-is-this"></a>
 </div>
 <div>
 <p>This book acts as an integration test for <code>mdbook-admonish</code>.</p>
 <p>It verifies that <code>mdbook</code> post-processes our generated HTML in the way we expect.</p>
 </div>
 </div>
-<div id="admonition-note" class="admonition admonish-note">
+<div id="admonition-note" class="admonition admonish-note" role="note" aria-labelledby="admonition-note-title">
 <div class="admonition-title">
+<div id="admonition-note-title">
 <p>Note</p>
-<p><a class="admonition-anchor-link" href="#admonition-note"></a></p>
+</div>
+<a class="admonition-anchor-link" href="#admonition-note"></a>
 </div>
 <div>
 <p>Simples</p>
 </div>
 </div>
-<div id="admonition-frog" class="admonition admonish-frog">
+<div id="admonition-frog" class="admonition admonish-frog" role="note" aria-labelledby="admonition-frog-title">
 <div class="admonition-title">
+<div id="admonition-frog-title">
 <p>Frog</p>
-<p><a class="admonition-anchor-link" href="#admonition-frog"></a></p>
+</div>
+<a class="admonition-anchor-link" href="#admonition-frog"></a>
 </div>
 <div>
 <p>Custom frog directive</p>
 </div>
 </div>
-<div id="admonition-default" class="admonition admonish-warning">
+<div id="admonition-default" class="admonition admonish-warning" role="note">
 <div>
 <p>No title, only body</p>
 </div>
 </div>
-<div id="admonition-error-rendering-admonishment" class="admonition admonish-bug">
+<div id="admonition-error-rendering-admonishment" class="admonition admonish-bug" role="note" aria-labelledby="admonition-error-rendering-admonishment-title">
 <div class="admonition-title">
+<div id="admonition-error-rendering-admonishment-title">
 <p>Error rendering admonishment</p>
-<p><a class="admonition-anchor-link" href="#admonition-error-rendering-admonishment"></a></p>
+</div>
+<a class="admonition-anchor-link" href="#admonition-error-rendering-admonishment"></a>
 </div>
 <div>
 <p>Failed with:</p>
@@ -55,38 +63,46 @@ No title, only body
 </code></pre>
 </div>
 </div>
-<details id="admonition-note-1" class="admonition admonish-note">
+<details id="admonition-note-1" class="admonition admonish-note" role="note" aria-labelledby="admonition-note-1-title">
 <summary class="admonition-title">
+<div id="admonition-note-1-title">
 <p>Note</p>
-<p><a class="admonition-anchor-link" href="#admonition-note-1"></a></p>
+</div>
+<a class="admonition-anchor-link" href="#admonition-note-1"></a>
 </summary>
 <div>
 <p>Hidden on load</p>
 </div>
 </details>
-<div id="admonition-warning" class="admonition admonish-warning">
+<div id="admonition-warning" class="admonition admonish-warning" role="note" aria-labelledby="admonition-warning-title">
 <div class="admonition-title">
+<div id="admonition-warning-title">
 <p>Warning</p>
-<p><a class="admonition-anchor-link" href="#admonition-warning"></a></p>
+</div>
+<a class="admonition-anchor-link" href="#admonition-warning"></a>
 </div>
 <div>
 <p>This is a commonly shared warning!</p>
 </div>
 </div>
-<div id="admonition-note-2" class="admonition admonish-note">
+<div id="admonition-note-2" class="admonition admonish-note" role="note" aria-labelledby="admonition-note-2-title">
 <div class="admonition-title">
+<div id="admonition-note-2-title">
 <p>Note</p>
-<p><a class="admonition-anchor-link" href="#admonition-note-2"></a></p>
+</div>
+<a class="admonition-anchor-link" href="#admonition-note-2"></a>
 </div>
 <div>
 <pre><code class="language-bash">Nested code block
 </code></pre>
 </div>
 </div>
-<div id="admonition-note-3" class="admonition admonish-note">
+<div id="admonition-note-3" class="admonition admonish-note" role="note" aria-labelledby="admonition-note-3-title">
 <div class="admonition-title">
+<div id="admonition-note-3-title">
 <p>Note</p>
-<p><a class="admonition-anchor-link" href="#admonition-note-3"></a></p>
+</div>
+<a class="admonition-anchor-link" href="#admonition-note-3"></a>
 </div>
 <div>
 <pre><pre class="playground"><code class="language-rust"><span class="boring">#![allow(unused)]
@@ -110,10 +126,12 @@ let x = 20;
 </li>
 <li>
 <p>Thing two</p>
-<div id="admonition-note-4" class="admonition admonish-note">
+<div id="admonition-note-4" class="admonition admonish-note" role="note" aria-labelledby="admonition-note-4-title">
 <div class="admonition-title">
+<div id="admonition-note-4-title">
 <p>Note</p>
-<p><a class="admonition-anchor-link" href="#admonition-note-4"></a></p>
+</div>
+<a class="admonition-anchor-link" href="#admonition-note-4"></a>
 </div>
 <div>
 <p>Thing two</p>

--- a/src/markdown.rs
+++ b/src/markdown.rs
@@ -155,11 +155,13 @@ Text
 
         let expected = r##"# Chapter
 
-<div id="admonition-note" class="admonition admonish-note">
+<div id="admonition-note" class="admonition admonish-note" role="note" aria-labelledby="admonition-note-title">
 <div class="admonition-title">
+<div id="admonition-note-title">
 
 Note
 
+</div>
 <a class="admonition-anchor-link" href="#admonition-note"></a>
 </div>
 <div>
@@ -187,11 +189,13 @@ Text
 
         let expected = r##"# Chapter
 
-<div id="admonition-note" class="admonition admonish-note">
+<div id="admonition-note" class="admonition admonish-note" role="note" aria-labelledby="admonition-note-title">
 <div class="admonition-title">
+<div id="admonition-note-title">
 
 Note
 
+</div>
 <a class="admonition-anchor-link" href="#admonition-note"></a>
 </div>
 <div>
@@ -219,11 +223,13 @@ Text
 
         let expected = r##"# Chapter
 
-<div id="admonition-warning" class="admonition admonish-warning">
+<div id="admonition-warning" class="admonition admonish-warning" role="note" aria-labelledby="admonition-warning-title">
 <div class="admonition-title">
+<div id="admonition-warning-title">
 
 Warning
 
+</div>
 <a class="admonition-anchor-link" href="#admonition-warning"></a>
 </div>
 <div>
@@ -249,11 +255,13 @@ Text
 
         let expected = r##"# Chapter
 
-<div id="admonition-caution" class="admonition admonish-warning">
+<div id="admonition-caution" class="admonition admonish-warning" role="note" aria-labelledby="admonition-caution-title">
 <div class="admonition-title">
+<div id="admonition-caution-title">
 
 Caution
 
+</div>
 <a class="admonition-anchor-link" href="#admonition-caution"></a>
 </div>
 <div>
@@ -279,11 +287,13 @@ Text
 
         let expected = r##"# Chapter
 
-<div id="admonition-read-this" class="admonition admonish-warning">
+<div id="admonition-read-this" class="admonition admonish-warning" role="note" aria-labelledby="admonition-read-this-title">
 <div class="admonition-title">
+<div id="admonition-read-this-title">
 
 Read **this**!
 
+</div>
 <a class="admonition-anchor-link" href="#admonition-read-this"></a>
 </div>
 <div>
@@ -373,11 +383,13 @@ hello
 
         let expected = r##"
 
-<div id="admonition-and-in-the-title" class="admonition admonish-note">
+<div id="admonition-and-in-the-title" class="admonition admonish-note" role="note" aria-labelledby="admonition-and-in-the-title-title">
 <div class="admonition-title">
+<div id="admonition-and-in-the-title-title">
 
 And "<i>in</i>" the title
 
+</div>
 <a class="admonition-anchor-link" href="#admonition-and-in-the-title"></a>
 </div>
 <div>
@@ -403,11 +415,13 @@ hello
 
         let expected = r##"
 
-<div id="admonition-trademark" class="admonition admonish-warning">
+<div id="admonition-trademark" class="admonition admonish-warning" role="note" aria-labelledby="admonition-trademark-title">
 <div class="admonition-title">
+<div id="admonition-trademark-title">
 
 Trademark™
 
+</div>
 <a class="admonition-anchor-link" href="#admonition-trademark"></a>
 </div>
 <div>
@@ -432,11 +446,13 @@ Will have bonus classnames
 
         let expected = r##"
 
-<div id="admonition-tip" class="admonition admonish-tip my-style other-style">
+<div id="admonition-tip" class="admonition admonish-tip my-style other-style" role="note" aria-labelledby="admonition-tip-title">
 <div class="admonition-title">
+<div id="admonition-tip-title">
 
 Tip
 
+</div>
 <a class="admonition-anchor-link" href="#admonition-tip"></a>
 </div>
 <div>
@@ -460,11 +476,13 @@ Will have bonus classnames
 
         let expected = r##"
 
-<div id="admonition-developers-dont-want-you-to-know-this-one-weird-tip" class="admonition admonish-tip my-style other-style">
+<div id="admonition-developers-dont-want-you-to-know-this-one-weird-tip" class="admonition admonish-tip my-style other-style" role="note" aria-labelledby="admonition-developers-dont-want-you-to-know-this-one-weird-tip-title">
 <div class="admonition-title">
+<div id="admonition-developers-dont-want-you-to-know-this-one-weird-tip-title">
 
 Developers don't want you to know this one weird tip!
 
+</div>
 <a class="admonition-anchor-link" href="#admonition-developers-dont-want-you-to-know-this-one-weird-tip"></a>
 </div>
 <div>
@@ -487,7 +505,7 @@ Will have bonus classnames
 
         let expected = r#"
 
-<div id="admonition-default" class="admonition admonish-note">
+<div id="admonition-default" class="admonition admonish-note" role="note">
 <div>
 
 
@@ -513,11 +531,13 @@ Content one.
 
         let expected = r##"
 
-<div id="admonition-my-note" class="admonition admonish-note">
+<div id="admonition-my-note" class="admonition admonish-note" role="note" aria-labelledby="admonition-my-note-title">
 <div class="admonition-title">
+<div id="admonition-my-note-title">
 
 My Note
 
+</div>
 <a class="admonition-anchor-link" href="#admonition-my-note"></a>
 </div>
 <div>
@@ -528,11 +548,13 @@ Content zero.
 </div>
 
 
-<div id="admonition-my-note-1" class="admonition admonish-note">
+<div id="admonition-my-note-1" class="admonition admonish-note" role="note" aria-labelledby="admonition-my-note-1-title">
 <div class="admonition-title">
+<div id="admonition-my-note-1-title">
 
 My Note
 
+</div>
 <a class="admonition-anchor-link" href="#admonition-my-note-1"></a>
 </div>
 <div>
@@ -556,11 +578,13 @@ Bonus content!
 
         let expected = r##"
 
-<div id="admonition-article-heading" class="admonition admonish-tip my other-style">
+<div id="admonition-article-heading" class="admonition admonish-tip my other-style" role="note" aria-labelledby="admonition-article-heading-title">
 <div class="admonition-title">
+<div id="admonition-article-heading-title">
 
 Article Heading
 
+</div>
 <a class="admonition-anchor-link" href="#admonition-article-heading"></a>
 </div>
 <div>
@@ -584,11 +608,13 @@ Bonus content!
 
         let expected = r##"
 
-<div id="admonition-error-rendering-admonishment" class="admonition admonish-bug">
+<div id="admonition-error-rendering-admonishment" class="admonition admonish-bug" role="note" aria-labelledby="admonition-error-rendering-admonishment-title">
 <div class="admonition-title">
+<div id="admonition-error-rendering-admonishment-title">
 
 Error rendering admonishment
 
+</div>
 <a class="admonition-anchor-link" href="#admonition-error-rendering-admonishment"></a>
 </div>
 <div>
@@ -686,11 +712,13 @@ Hidden
 
         let expected = r##"
 
-<details id="admonition-note" class="admonition admonish-note">
+<details id="admonition-note" class="admonition admonish-note" role="note" aria-labelledby="admonition-note-title">
 <summary class="admonition-title">
+<div id="admonition-note-title">
 
 Note
 
+</div>
 <a class="admonition-anchor-link" href="#admonition-note"></a>
 </summary>
 <div>
@@ -715,11 +743,13 @@ Text
 
         let expected = r##"# Chapter
 
-<div id="admonition-admonish" class="admonition admonish-note">
+<div id="admonition-admonish" class="admonition admonish-note" role="note" aria-labelledby="admonition-admonish-title">
 <div class="admonition-title">
+<div id="admonition-admonish-title">
 
 Admonish
 
+</div>
 <a class="admonition-anchor-link" href="#admonition-admonish"></a>
 </div>
 <div>
@@ -759,7 +789,7 @@ Text
 
         let expected = r#"# Chapter
 
-<div id="admonition-default" class="admonition admonish-note">
+<div id="admonition-default" class="admonition admonish-note" role="note">
 <div>
 
 A simple admonition.
@@ -797,7 +827,7 @@ Text
 
         let expected = r#"# Chapter
 
-<div id="admonition-default" class="admonition admonish-note">
+<div id="admonition-default" class="admonition admonish-note" role="note">
 <div>
 
 A simple admonition.
@@ -821,11 +851,13 @@ Text
 
         let expected = r##"# Chapter
 
-<div id="yay-custom-id" class="admonition admonish-success">
+<div id="yay-custom-id" class="admonition admonish-success" role="note" aria-labelledby="yay-custom-id-title">
 <div class="admonition-title">
+<div id="yay-custom-id-title">
 
 Check
 
+</div>
 <a class="admonition-anchor-link" href="#yay-custom-id"></a>
 </div>
 <div>
@@ -851,11 +883,13 @@ Text
 
         let expected = r##"# Chapter
 
-<div id="admonition-check" class="admonition admonish-success">
+<div id="admonition-check" class="admonition admonish-success" role="note" aria-labelledby="admonition-check-title">
 <div class="admonition-title">
+<div id="admonition-check-title">
 
 Check
 
+</div>
 <a class="admonition-anchor-link" href="#admonition-check"></a>
 </div>
 <div>
@@ -881,11 +915,13 @@ Text
 
         let expected = r##"# Chapter
 
-<div id="admonition-check-mark" class="admonition admonish-success">
+<div id="admonition-check-mark" class="admonition admonish-success" role="note" aria-labelledby="admonition-check-mark-title">
 <div class="admonition-title">
+<div id="admonition-check-mark-title">
 
 Check Mark
 
+</div>
 <a class="admonition-anchor-link" href="#admonition-check-mark"></a>
 </div>
 <div>
@@ -914,11 +950,13 @@ Text
 
         let expected = r##"# Chapter
 
-<div id="admonition-check-mark" class="admonition admonish-success">
+<div id="admonition-check-mark" class="admonition admonish-success" role="note" aria-labelledby="admonition-check-mark-title">
 <div class="admonition-title">
+<div id="admonition-check-mark-title">
 
 Check <span class="emphasis">Mark</span>
 
+</div>
 <a class="admonition-anchor-link" href="#admonition-check-mark"></a>
 </div>
 <div>
@@ -944,11 +982,13 @@ Text
 
         let expected = r##"# Chapter
 
-<div id="info" class="admonition admonish-info">
+<div id="info" class="admonition admonish-info" role="note" aria-labelledby="info-title">
 <div class="admonition-title">
+<div id="info-title">
 
 Info
 
+</div>
 <a class="admonition-anchor-link" href="#info"></a>
 </div>
 <div>
@@ -988,11 +1028,13 @@ Text
 
         let expected = r##"# Chapter
 
-<div id="prefix-my-title" class="admonition admonish-info">
+<div id="prefix-my-title" class="admonition admonish-info" role="note" aria-labelledby="prefix-my-title-title">
 <div class="admonition-title">
+<div id="prefix-my-title-title">
 
 My Title
 
+</div>
 <a class="admonition-anchor-link" href="#prefix-my-title"></a>
 </div>
 <div>
@@ -1032,11 +1074,13 @@ Text
 
         let expected = r##"# Chapter
 
-<div id="my-section-id" class="admonition admonish-info">
+<div id="my-section-id" class="admonition admonish-info" role="note" aria-labelledby="my-section-id-title">
 <div class="admonition-title">
+<div id="my-section-id-title">
 
 My Title
 
+</div>
 <a class="admonition-anchor-link" href="#my-section-id"></a>
 </div>
 <div>
@@ -1099,11 +1143,13 @@ Text
 1. Thing two
 
    
-   <div id="admonition-note" class="admonition admonish-note">
+   <div id="admonition-note" class="admonition admonish-note" role="note" aria-labelledby="admonition-note-title">
    <div class="admonition-title">
+   <div id="admonition-note-title">
    
    Note
    
+   </div>
    <a class="admonition-anchor-link" href="#admonition-note"></a>
    </div>
    <div>

--- a/src/preprocessor.rs
+++ b/src/preprocessor.rs
@@ -178,11 +178,13 @@ x = 20;
 "#;
         let expected_content = r##"
 
-<div id="admonition-title" class="admonition admonish-note">
+<div id="admonition-title" class="admonition admonish-note" role="note" aria-labelledby="admonition-title-title">
 <div class="admonition-title">
+<div id="admonition-title-title">
 
 Title
 
+</div>
 <a class="admonition-anchor-link" href="#admonition-title"></a>
 </div>
 <div>

--- a/src/render.rs
+++ b/src/render.rs
@@ -35,9 +35,9 @@ impl<'a> Admonition<'a> {
         }
     }
 
-    pub(crate) fn html(&self, id_counter: &mut HashMap<String, usize>) -> String {
+    pub(crate) fn html(self, id_counter: &mut HashMap<String, usize>) -> String {
         let anchor_id = match &self.css_id {
-            CssId::Verbatim(id) => Cow::Borrowed(id),
+            CssId::Verbatim(id) => Cow::Borrowed(id.as_str()),
             CssId::Prefix(prefix) => {
                 let id = unique_id_from_content(
                     if !self.title.is_empty() {
@@ -56,53 +56,68 @@ impl<'a> Admonition<'a> {
         let content = &self.content;
         let indent = " ".repeat(self.indent);
 
-        let title_block = if self.collapsible { "summary" } else { "div" };
-
-        let title_html = if !title.is_empty() {
-            Cow::Owned(format!(
-                r##"{indent}<{title_block} class="admonition-title">
+        let (titlebar_html, _title_id) = if !title.is_empty() {
+            let titlebar_element = if self.collapsible { "summary" } else { "div" };
+            let title_id = format!("{anchor_id}-title");
+            let titlebar_html = Cow::Owned(format!(
+                r##"{indent}<{titlebar_element} class="admonition-title">
 {indent}
 {indent}{title}
 {indent}
 {indent}<a class="admonition-anchor-link" href="#{anchor_id}"></a>
-{indent}</{title_block}>
+{indent}</{titlebar_element}>
 "##
-            ))
+            ));
+            (titlebar_html, Some(title_id))
         } else {
-            Cow::Borrowed("")
+            (Cow::Borrowed(""), None)
         };
 
-        let mut additional_class = format!("admonish-{}", self.directive);
-        if !self.additional_classnames.is_empty() {
-            for additional_classname in &self.additional_classnames {
-                additional_class.push(' ');
-                additional_class.push_str(additional_classname);
-            }
-        }
+        let mut classes = vec![
+            "admonition".to_owned(),
+            format!("admonish-{}", self.directive),
+        ];
+        classes.extend(self.additional_classnames);
+        let classes = classes.join(" ");
 
-        let admonition_block = if self.collapsible { "details" } else { "div" };
+        let mut attributes = vec![("id", anchor_id), ("class", Cow::Owned(classes))];
+        let attributes = join_attributes(&attributes);
+
+        let admonition_element = if self.collapsible { "details" } else { "div" };
         // Notes on the HTML template:
         // - the additional whitespace around the content are deliberate
         //   In line with the commonmark spec, this allows the inner content to be
         //   rendered as markdown paragraphs.
         format!(
             r#"
-{indent}<{admonition_block} id="{anchor_id}" class="admonition {additional_class}">
-{title_html}{indent}<div>
+{indent}<{admonition_element} {attributes}>
+{titlebar_html}{indent}<div>
 {indent}
 {indent}{content}
 {indent}
 {indent}</div>
-{indent}</{admonition_block}>"#,
+{indent}</{admonition_element}>"#,
         )
     }
 
     /// Strips all admonish syntax, leaving the plain content of the block.
-    pub(crate) fn strip(&self) -> String {
+    pub(crate) fn strip(self) -> String {
         // Add in newlines to preserve line numbering for test output
         // These replace the code fences we stripped out
         format!("\n{}\n", self.content)
     }
+}
+
+fn join_attributes(attributes: &[(impl AsRef<str>, impl AsRef<str>)]) -> String {
+    let mut buffer = String::new();
+    for (key, value) in attributes {
+        buffer.push_str(key.as_ref());
+        buffer.push_str(r#"=""#);
+        buffer.push_str(value.as_ref());
+        buffer.push_str(r#"" "#);
+    }
+    buffer.pop();
+    buffer
 }
 
 const ANCHOR_ID_DEFAULT: &str = "default";

--- a/src/render.rs
+++ b/src/render.rs
@@ -56,14 +56,16 @@ impl<'a> Admonition<'a> {
         let content = &self.content;
         let indent = " ".repeat(self.indent);
 
-        let (titlebar_html, _title_id) = if !title.is_empty() {
+        let (titlebar_html, title_id) = if !title.is_empty() {
             let titlebar_element = if self.collapsible { "summary" } else { "div" };
             let title_id = format!("{anchor_id}-title");
             let titlebar_html = Cow::Owned(format!(
                 r##"{indent}<{titlebar_element} class="admonition-title">
+{indent}<div id="{title_id}">
 {indent}
 {indent}{title}
 {indent}
+{indent}</div>
 {indent}<a class="admonition-anchor-link" href="#{anchor_id}"></a>
 {indent}</{titlebar_element}>
 "##
@@ -80,7 +82,14 @@ impl<'a> Admonition<'a> {
         classes.extend(self.additional_classnames);
         let classes = classes.join(" ");
 
-        let mut attributes = vec![("id", anchor_id), ("class", Cow::Owned(classes))];
+        let mut attributes = vec![
+            ("id", anchor_id),
+            ("class", Cow::Owned(classes)),
+            ("role", Cow::Borrowed("note")),
+        ];
+        if let Some(title_id) = title_id {
+            attributes.push(("aria-labelledby", Cow::Owned(title_id)));
+        }
         let attributes = join_attributes(&attributes);
 
         let admonition_element = if self.collapsible { "details" } else { "div" };


### PR DESCRIPTION
Closes #193 

This PR:

- Refactors some of the HTML generation logic to make it more ergonomic
- Adds the `aria-labelledby` and `role` attributes