### PR TITLE
fix: use up to date toml for serialization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -983,7 +983,6 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "toml 0.5.11",
  "toml 0.8.13",
  "toml_edit",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,10 +41,6 @@ regex = "1.9.6"
 semver = "1.0.19"
 serde = { version = "1.0.188", features = ["derive"] }
 serde_json = "1.0.107"
-# Peer dependency of mdbook
-# The version of toml that mdbook uses internally (and uses in it's public api)
-# Only used for compatilibilty with the mdbook public api
-toml_mdbook = { package = "toml", version = "0.5.11" }
 toml = "0.8.1"
 toml_edit = { version = "0.22.13", optional = true }
 hex_color = { version = "3.0.0", features = ["serde"] }

--- a/src/bin/mdbook-admonish.rs
+++ b/src/bin/mdbook-admonish.rs
@@ -125,7 +125,7 @@ struct Preprocessors {
 
 /// Load the plugin specific config as a toml string, for private deserialization.
 fn admonish_config_string(config: &Config) -> Result<String> {
-    Ok(toml_mdbook::to_string(
+    Ok(toml::to_string(
         &config
             .preprocessor
             .admonish

--- a/src/book_config.rs
+++ b/src/book_config.rs
@@ -11,11 +11,12 @@ use crate::types::{AdmonitionDefaults, BuiltinDirective, BuiltinDirectiveConfig}
 /// Roundtrips config to string, to avoid linking the plugin's internal version of toml
 /// to the one publically exposed by the mdbook library.
 pub(crate) fn admonish_config_from_context(ctx: &PreprocessorContext) -> Result<Config> {
-    let table: String = toml_mdbook::to_string(
+    let table: String = toml::to_string(
         ctx.config
             .get_preprocessor("admonish")
             .context("No configuration for mdbook-admonish in book.toml")?,
-    )?;
+    )
+    .context("Could not serialize mdbook-admonish config. This is a bug in the toml library.")?;
     admonish_config_from_str(&table)
 }
 


### PR DESCRIPTION
Closes #196 

I was working under a false assumption that because `mdbook` uses `toml 0.5.11` internally, (i.e. the values that is exposes in the public api are `toml::Value`s from `0.5.11`), we had to use a matching `toml` version to perform serde operations on them.

This is not true, so we can upgrade to avoid the known bugs like #196! This would have been great to know about three months ago, but TIL.