### PR TITLE
fix: do not double indent content in lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,14 @@
 # Changelog
 
-## Unreleased
+## v1.19.0
 
 ### Changed
 
 - MSRV (minimum supported rust version) is now 1.76.0 ([#208](https://github.com/tommilligan/mdbook-admonish/pull/208))
+
+### Fixed
+
+- Fixed blocks not rendering correctly in indented list items. Thanks to [@JorelAli](https://github.com/JorelAli) for the bug report! ([#224](https://github.com/tommilligan/mdbook-admonish/pull/224))
 
 ## v1.18.0
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -981,7 +981,7 @@ dependencies = [
 
 [[package]]
 name = "mdbook-admonish"
-version = "1.18.0"
+version = "1.19.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mdbook-admonish"
-version = "1.18.0"
+version = "1.19.0"
 edition = "2021"
 rust-version = "1.76.0"
 

--- a/integration/expected/chapter_1_main.html
+++ b/integration/expected/chapter_1_main.html
@@ -137,6 +137,23 @@ let x = 20;
 <p>Thing two</p>
 </div>
 </div>
+<ol>
+<li>
+<p>Thing two nested</p>
+<div id="admonition-note-5" class="admonition admonish-note" role="note" aria-labelledby="admonition-note-5-title">
+<div class="admonition-title">
+<div id="admonition-note-5-title">
+<p>Note</p>
+</div>
+<a class="admonition-anchor-link" href="#admonition-note-5"></a>
+</div>
+<div>
+<p>Thing two nested (should not be a code block)
+Regression tests for https://github.com/tommilligan/mdbook-admonish/issues/223</p>
+</div>
+</div>
+</li>
+</ol>
 </li>
 <li>
 <p>Thing three</p>

--- a/integration/src/chapter_1.md
+++ b/integration/src/chapter_1.md
@@ -60,6 +60,13 @@ In a list:
    Thing two
    ```
 
+   1. Thing two nested
+   
+      ```admonish
+      Thing two nested (should not be a code block)
+      Regression tests for https://github.com/tommilligan/mdbook-admonish/issues/223
+      ```
+
 1. Thing three
 
    ```sh

--- a/src/markdown.rs
+++ b/src/markdown.rs
@@ -1153,9 +1153,9 @@ Text
    <a class="admonition-anchor-link" href="#admonition-note"></a>
    </div>
    <div>
-   
-      Thing two
-   
+
+   Thing two
+
    </div>
    </div>
 
@@ -1164,6 +1164,99 @@ Text
    ```sh
    Thing three
    ```
+"##;
+
+        assert_eq!(expected, prep(content));
+    }
+
+    // Regression test for https://github.com/tommilligan/mdbook-admonish/issues/223
+    #[test]
+    fn nested_list_should_not_render_indented_code_block() {
+        let content = r#"# Chapter
+
+- Level one
+
+  ```admonish
+  Thing one
+  line two
+  ```
+
+  - Level two
+
+    ```admonish
+    Thing two
+    line two
+    ```
+
+    - Level three
+
+      ```admonish
+      Thing three
+      line two
+      ```
+"#;
+
+        let expected = r##"# Chapter
+
+- Level one
+
+  
+  <div id="admonition-note" class="admonition admonish-note" role="note" aria-labelledby="admonition-note-title">
+  <div class="admonition-title">
+  <div id="admonition-note-title">
+  
+  Note
+  
+  </div>
+  <a class="admonition-anchor-link" href="#admonition-note"></a>
+  </div>
+  <div>
+
+  Thing one
+  line two
+
+  </div>
+  </div>
+
+  - Level two
+
+    
+    <div id="admonition-note-1" class="admonition admonish-note" role="note" aria-labelledby="admonition-note-1-title">
+    <div class="admonition-title">
+    <div id="admonition-note-1-title">
+    
+    Note
+    
+    </div>
+    <a class="admonition-anchor-link" href="#admonition-note-1"></a>
+    </div>
+    <div>
+
+    Thing two
+    line two
+
+    </div>
+    </div>
+
+    - Level three
+
+      
+      <div id="admonition-note-2" class="admonition admonish-note" role="note" aria-labelledby="admonition-note-2-title">
+      <div class="admonition-title">
+      <div id="admonition-note-2-title">
+      
+      Note
+      
+      </div>
+      <a class="admonition-anchor-link" href="#admonition-note-2"></a>
+      </div>
+      <div>
+
+      Thing three
+      line two
+
+      </div>
+      </div>
 "##;
 
         assert_eq!(expected, prep(content));

--- a/src/render.rs
+++ b/src/render.rs
@@ -97,13 +97,15 @@ impl<'a> Admonition<'a> {
         // - the additional whitespace around the content are deliberate
         //   In line with the commonmark spec, this allows the inner content to be
         //   rendered as markdown paragraphs.
+        // - We should not indent the inner content, as it retains the indent
+        //   it is written with.
         format!(
             r#"
 {indent}<{admonition_element} {attributes}>
 {titlebar_html}{indent}<div>
-{indent}
-{indent}{content}
-{indent}
+
+{content}
+
 {indent}</div>
 {indent}</{admonition_element}>"#,
         )


### PR DESCRIPTION
Closes https://github.com/tommilligan/mdbook-admonish/issues/223